### PR TITLE
Correct invalid data sent to the bitbucket repository apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,21 @@ Bottle Rocket Android Architecture Guidelines
 * Clone project to local machine
 * Open project in Android Studio
 * If prompted, select "Default Gradle Wrapper"
-* Project should open and Gradle should sync without any issues. 
+* Project should open and Gradle should sync without any issues.
+
+## OAuth consumer key creation and setup steps
 * Generate a Bitbucket OAuth consumer key at https://bitbucket.org/[your-bitbucket-username]/workspace/settings/api
+    * You must specify a callback url. The value isn't important, so go ahead and use https://www.bottlerocketstudios.com/
+    * You must enable the following permissions (at a minimum) to ensure proper functioning of the app:
+        * **Account** read
+        * **Snippets** read/write
+        * **Repositories** read
 * Create a file in project root named "apikey.properties" with following format:
-BITBUCKET_KEY="<key>"
-BITBUCKET_SECRET="<secret>"
+
+```
+BITBUCKET_KEY="[oauth_consumer_key]"
+BITBUCKET_SECRET="[oauth_consumer_secret]"
+```
 
 ### Primary Docs
 * **Required reading** - [BEST_PRACTICES.md](./docs/BEST_PRACTICES.md) for Android engineering team norms for the project.

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileFragment.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileFragment.kt
@@ -24,7 +24,7 @@ class RepositoryFileFragment : BaseFragment<RepositoryFileFragmentViewModel, Rep
         activityViewModel.setTitle(file.path ?: "")
         activityViewModel.showToolbar(true)
         fragmentViewModel.loadFile(
-            repo.owner?.nickname ?: "",
+            repo.workspace?.slug ?: "",
             repo.name ?: "",
             file.mimetype ?: "",
             file.commit?.hash ?: "",

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileFragmentViewModel.kt
@@ -12,10 +12,10 @@ import kotlinx.coroutines.launch
 class RepositoryFileFragmentViewModel(app: Application, private val repo: BitbucketRepository, private val dispatcherProvider: DispatcherProvider) : BaseViewModel(app) {
     val srcFile: LiveData<String?> = MutableLiveData()
     val path: LiveData<String?> = MutableLiveData()
-    fun loadFile(owner: String, repoId: String, @Suppress("UNUSED_PARAMETER") mimetype: String, hash: String, path: String) {
+    fun loadFile(workspaceSlug: String, repoId: String, @Suppress("UNUSED_PARAMETER") mimetype: String, hash: String, path: String) {
         viewModelScope.launch(dispatcherProvider.IO) {
             // TODO: Differentiate UI per type of content (ex: image/text/etc)
-            srcFile.postValue(repo.getSourceFile(owner, repoId, hash, path))
+            srcFile.postValue(repo.getSourceFile(workspaceSlug, repoId, hash, path))
             this@RepositoryFileFragmentViewModel.path.postValue(path)
         }
     }

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFolderFragment.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFolderFragment.kt
@@ -55,7 +55,7 @@ class RepositoryFolderFragment : BaseFragment<RepositoryFolderFragmentViewModel,
             fileList.layoutManager = LinearLayoutManager(this@RepositoryFolderFragment.activity)
 
             fragmentViewModel.loadRepo(
-                repo.owner?.nickname ?: "",
+                repo.workspace?.slug ?: "",
                 repo.name ?: "",
                 folder.commit?.hash ?: "",
                 folder.path ?: ""

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFolderFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFolderFragmentViewModel.kt
@@ -29,9 +29,9 @@ class RepositoryFolderFragmentViewModel(app: Application, private val repo: Bitb
         srcFiles.observeForever(filesObserver)
     }
 
-    fun loadRepo(owner: String, repoId: String, hash: String, path: String) {
+    fun loadRepo(workspaceSlug: String, repoId: String, hash: String, path: String) {
         viewModelScope.launch(dispatcherProvider.IO) {
-            srcFiles.postValue(repo.getSourceFolder(owner, repoId, hash, path))
+            srcFiles.postValue(repo.getSourceFolder(workspaceSlug, repoId, hash, path))
             this@RepositoryFolderFragmentViewModel.path = path
         }
     }

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFragmentViewModel.kt
@@ -24,10 +24,10 @@ class RepositoryFragmentViewModel(app: Application, private val repo: BitbucketR
         selectedId = id
         repos.value?.firstOrNull { it.name?.equals(id) ?: false }?.let {
             selectedRepository.set(it)
-            it.owner?.nickname?.let { nickname ->
+            it.workspace?.slug?.let { workspaceSlug ->
                 it.name?.let { repoName ->
                     viewModelScope.launch(dispatcherProvider.IO) {
-                        srcFiles.postValue(repo.getSource(nickname, repoName))
+                        srcFiles.postValue(repo.getSource(workspaceSlug, repoName))
                     }
                 }
             }

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/snippet/CreateSnippetFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/snippet/CreateSnippetFragmentViewModel.kt
@@ -21,7 +21,7 @@ class CreateSnippetFragmentViewModel(app: Application, private val repo: Bitbuck
     val failed: LiveData<Boolean> = MutableLiveData()
 
     val textWatcher = Observer<String> { _ ->
-        createEnabled.postValue(!(title.value.isNullOrEmpty()||filename.value.isNullOrEmpty()||contents.value.isNullOrEmpty()))
+        createEnabled.postValue(!(title.value.isNullOrEmpty() || filename.value.isNullOrEmpty() || contents.value.isNullOrEmpty()))
     }
 
     init {
@@ -32,22 +32,20 @@ class CreateSnippetFragmentViewModel(app: Application, private val repo: Bitbuck
 
     fun onCreateClick() {
         failed.postValue(false)
-        repo.user.value?.uuid?.let { userString ->
-            title.value?.let { titleString ->
-                filename.value?.let { filenameString ->
-                    contents.value?.let { contentsString ->
-                        viewModelScope.launch(dispatcherProvider.IO) {
-                            val result = repo.createSnippet(userString, titleString, filenameString, contentsString, private.value ?: false)
-                            if (result) {
-                                navigationEvent.postValue(NavigationEvent.Up)
-                            } else {
-                                failed.postValue(true)
-                            }
+        title.value?.let { titleString ->
+            filename.value?.let { filenameString ->
+                contents.value?.let { contentsString ->
+                    viewModelScope.launch(dispatcherProvider.IO) {
+                        val result = repo.createSnippet(titleString, filenameString, contentsString, private.value ?: false)
+                        if (result) {
+                            navigationEvent.postValue(NavigationEvent.Up)
+                        } else {
+                            failed.postValue(true)
                         }
-                    } ?: Timber.e("Snippet creation failed because contents was unexpectedly null")
-                } ?: Timber.e("Snippet creation failed because filename was unexpectedly null")
-            } ?: Timber.e("Snippet creation failed because title was unexpectedly null")
-        } ?: Timber.e("Snippet creation failed because user uuid was unexpectedly null")
+                    }
+                } ?: Timber.e("Snippet creation failed because contents was unexpectedly null")
+            } ?: Timber.e("Snippet creation failed because filename was unexpectedly null")
+        } ?: Timber.e("Snippet creation failed because title was unexpectedly null")
     }
 
     override fun onCleared() {

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/model/Repository.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/model/Repository.kt
@@ -16,6 +16,7 @@ data class Repository(
     @Json(name = "scm") val scm: String? = "",
     @Json(name = "name") val name: String? = "",
     @Json(name = "owner") val owner: User? = null,
+    @Json(name = "workspace") val workspace: Workspace? = null,
     @Json(name = "is_private") val isPrivate: Boolean? = true,
     @Json(name = "description") val description: String? = "",
     @Json(name = "updated_on") val updated: ZonedDateTime? = null

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/model/Workspace.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/model/Workspace.kt
@@ -1,0 +1,14 @@
+package com.bottlerocketstudios.brarchitecture.data.model
+
+import android.os.Parcelable
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import kotlinx.android.parcel.Parcelize
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class Workspace(
+    @Json(name = "slug") val slug: String? = "",
+    @Json(name = "name") val name: String? = "",
+    @Json(name = "uuid") val uuid: String? = ""
+) : Parcelable

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/BitbucketService.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/BitbucketService.kt
@@ -19,38 +19,38 @@ internal interface BitbucketService {
     fun getUser(): Call<User>
 
     /** https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D */
-    @GET(value = "2.0/repositories/{owner}")
+    @GET(value = "2.0/repositories/{workspace}")
     fun getRepositories(
-        @Path(value = "owner") owner: String
+        @Path(value = "workspace") workspace: String
     ): Call<BitbucketPagedResponse<List<Repository>>>
 
     /** https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D */
-    @GET(value = "2.0/repositories/{owner}/{repo}")
+    @GET(value = "2.0/repositories/{workspace}/{repo}")
     fun getRepository(
-        @Path(value = "owner") owner: String,
+        @Path(value = "workspace") workspace: String,
         @Path(value = "repo") repo: String
     ): Call<Repository>
 
     /** https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src */
-    @GET(value = "2.0/repositories/{owner}/{repo}/src")
+    @GET(value = "2.0/repositories/{workspace}/{repo}/src")
     fun getRepositorySource(
-        @Path(value = "owner") owner: String,
+        @Path(value = "workspace") workspace: String,
         @Path(value = "repo") repo: String
     ): Call<BitbucketPagedResponse<List<RepoFile>>>
 
     /** https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src/%7Bnode%7D/%7Bpath%7D */
-    @GET(value = "2.0/repositories/{owner}/{repo}/src/{hash}/{path}")
+    @GET(value = "2.0/repositories/{workspace}/{repo}/src/{hash}/{path}")
     fun getRepositorySourceFolder(
-        @Path(value = "owner") owner: String,
+        @Path(value = "workspace") workspace: String,
         @Path(value = "repo") repo: String,
         @Path(value = "hash") hash: String,
         @Path(value = "path") path: String
     ): Call<BitbucketPagedResponse<List<RepoFile>>>
 
     /** https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src/%7Bnode%7D/%7Bpath%7D */
-    @GET(value = "2.0/repositories/{owner}/{repo}/src/{hash}/{path}")
+    @GET(value = "2.0/repositories/{workspace}/{repo}/src/{hash}/{path}")
     fun getRepositorySourceFile(
-        @Path(value = "owner") owner: String,
+        @Path(value = "workspace") workspace: String,
         @Path(value = "repo") repo: String,
         @Path(value = "hash") hash: String,
         @Path(value = "path") path: String

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/repository/BitbucketRepository.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/repository/BitbucketRepository.kt
@@ -21,12 +21,12 @@ interface BitbucketRepository {
     fun refreshUser(): Boolean
     fun refreshMyRepos(): Boolean
     fun refreshMySnippets(): Boolean
-    fun getRepositories(owner: String): List<Repository>
-    fun getRepository(owner: String, repo: String): Repository?
-    fun getSource(owner: String, repo: String): List<RepoFile>?
-    fun getSourceFolder(owner: String, repo: String, hash: String, path: String): List<RepoFile>?
-    fun getSourceFile(owner: String, repo: String, hash: String, path: String): String?
-    fun createSnippet(owner: String, title: String, filename: String, contents: String, private: Boolean): Boolean
+    fun getRepositories(workspaceSlug: String): List<Repository>
+    fun getRepository(workspaceSlug: String, repo: String): Repository?
+    fun getSource(workspaceSlug: String, repo: String): List<RepoFile>?
+    fun getSourceFolder(workspaceSlug: String, repo: String, hash: String, path: String): List<RepoFile>?
+    fun getSourceFile(workspaceSlug: String, repo: String, hash: String, path: String): String?
+    fun createSnippet(title: String, filename: String, contents: String, private: Boolean): Boolean
     fun clear()
 }
 
@@ -64,6 +64,7 @@ internal class BitbucketRepositoryImplementation(private val bitbucketService: B
     }
 
     override fun refreshMyRepos(): Boolean {
+        // TODO: Add support for handling multiple workspaces, as using the user.username might only map to the first workspace created.
         val response = bitbucketService.getRepositories(_user.value?.username ?: "").execute()
         if (response.isSuccessful) {
             _repos.postValue(response.body()?.values)
@@ -79,47 +80,47 @@ internal class BitbucketRepositoryImplementation(private val bitbucketService: B
         return response.isSuccessful
     }
 
-    override fun getRepositories(owner: String): List<Repository> {
-        val response = bitbucketService.getRepositories(owner).execute()
+    override fun getRepositories(workspaceSlug: String): List<Repository> {
+        val response = bitbucketService.getRepositories(workspaceSlug).execute()
         if (response.isSuccessful) {
             return response.body()?.values ?: emptyList()
         }
         return emptyList()
     }
 
-    override fun getRepository(owner: String, repo: String): Repository? {
-        val response = bitbucketService.getRepository(owner, repo).execute()
+    override fun getRepository(workspaceSlug: String, repo: String): Repository? {
+        val response = bitbucketService.getRepository(workspaceSlug, repo).execute()
         if (response.isSuccessful) {
             return response.body()
         }
         return null
     }
 
-    override fun getSource(owner: String, repo: String): List<RepoFile>? {
-        val response = bitbucketService.getRepositorySource(owner, repo).execute()
+    override fun getSource(workspaceSlug: String, repo: String): List<RepoFile>? {
+        val response = bitbucketService.getRepositorySource(workspaceSlug, repo).execute()
         if (response.isSuccessful) {
             return response.body()?.values ?: emptyList()
         }
         return null
     }
 
-    override fun getSourceFolder(owner: String, repo: String, hash: String, path: String): List<RepoFile>? {
-        val response = bitbucketService.getRepositorySourceFolder(owner, repo, hash, path).execute()
+    override fun getSourceFolder(workspaceSlug: String, repo: String, hash: String, path: String): List<RepoFile>? {
+        val response = bitbucketService.getRepositorySourceFolder(workspaceSlug, repo, hash, path).execute()
         if (response.isSuccessful) {
             return response.body()?.values ?: emptyList()
         }
         return null
     }
 
-    override fun getSourceFile(owner: String, repo: String, hash: String, path: String): String? {
-        val response = bitbucketService.getRepositorySourceFile(owner, repo, hash, path).execute()
+    override fun getSourceFile(workspaceSlug: String, repo: String, hash: String, path: String): String? {
+        val response = bitbucketService.getRepositorySourceFile(workspaceSlug, repo, hash, path).execute()
         if (response.isSuccessful) {
             return response.body() ?: ""
         }
         return null
     }
 
-    override fun createSnippet(owner: String, title: String, filename: String, contents: String, private: Boolean): Boolean {
+    override fun createSnippet(title: String, filename: String, contents: String, private: Boolean): Boolean {
         val body = MultipartBody.Part.createFormData("file", filename, RequestBody.create(MediaType.get("text/plain"), contents))
         val response = bitbucketService.createSnippet(title, body, private).execute()
         return response.isSuccessful

--- a/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/model/RepositoryTest.kt
+++ b/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/model/RepositoryTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class RepositoryTest : BaseTest() {
     @Test
     fun repository_shouldHaveFields_whenConstructed() {
-        val repository = Repository("scm", "name", null, true)
+        val repository = Repository("scm", "name", null, null, true)
         assertThat(repository.scm).isEqualTo("scm")
         assertThat(repository.name).isEqualTo("name")
         assertThat(repository.isPrivate).isTrue()


### PR DESCRIPTION
### Observations
After creating a new OAuth consumer key/secret and test bitbucket account to use for testing the app flow and UI, I observed that repositories were not loading properly. Looking further into the api docs, it was mentioned that the workspace slug (id) or uuid should be used instead of passing in the repository owner nickname (which might have worked earlier due to the values being the same for the previous test Bitbucket account used).

### Changes
* Refactor owner to workspace/workspaceSlug starting with the BitbucketService definitions and bubbling up through the call hierarchy
* Send repository.workspace.slug in place of repository.owner.nickname from all appropriate call sites
* Update README documentation mentioning additional detail around Bitbucket OAuth consumer key creation and setup