### PR TITLE
Update codebase to use Arctic Fox 2020.3.1 in combination with AGP 7.0.0

### DIFF
--- a/.idea/runConfigurations/_app___testInternalDebugUnitTest.xml
+++ b/.idea/runConfigurations/_app___testInternalDebugUnitTest.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name=":app - testInternalDebugUnitTest" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/app" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--tests &quot;*&quot;" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":app:cleanTestInternalDebugUnitTest" />
+          <option value=":app:testInternalDebugUnitTest" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/_data___testInternalDebugUnitTest.xml
+++ b/.idea/runConfigurations/_data___testInternalDebugUnitTest.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name=":data - testInternalDebugUnitTest" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/data" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--tests &quot;*&quot;" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":data:cleanTestInternalDebugUnitTest" />
+          <option value=":data:testInternalDebugUnitTest" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariantOutput
 
@@ -28,22 +29,28 @@ BuildInfoManager.initialize(
 // android {...} DSL Reference:
 // Android Gradle Plugin api: https://developer.android.com/reference/tools/gradle-api/4.1/classes
 android {
-    compileSdkVersion(Config.AndroidSdkVersions.COMPILE_SDK)
+    compileSdk = Config.AndroidSdkVersions.COMPILE_SDK
     buildToolsVersion = Config.AndroidSdkVersions.BUILD_TOOLS
     defaultConfig {
-        minSdkVersion(Config.AndroidSdkVersions.MIN_SDK)
-        targetSdkVersion(Config.AndroidSdkVersions.TARGET_SDK)
+        minSdk = Config.AndroidSdkVersions.MIN_SDK
+        targetSdk = Config.AndroidSdkVersions.TARGET_SDK
         versionCode = BuildInfoManager.APP_VERSION.versionCode
         versionName = BuildInfoManager.APP_VERSION.versionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
         isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
+    }
+    lint {
+        // TODO: Remove once Timber is updated past 4.7.1 with AGP 7.0.0 related lint fixes: https://github.com/JakeWharton/timber/issues/408
+        disable.addAll(
+            setOf("LogNotTimber", "StringFormatInTimber", "ThrowableNotAtBeginning", "BinaryOperationInTimber", "TimberArgCount", "TimberArgTypes", "TimberTagLength", "TimberExceptionLogging")
+        )
     }
     signingConfigs {
         getByName("debug") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,6 +19,6 @@ dependencies {
     // Found in https://quickbirdstudios.com/blog/gradle-kotlin-buildsrc-plugin-android/
     // Unable to use a single source of truth due to issue mentioned in https://github.com/gradle/kotlin-dsl-samples/issues/1320#issuecomment-486309410
     // TODO: These should be updated in tandem with source of truth values in Dependencies.kt.
-    implementation("com.android.tools.build:gradle:4.2.1")
+    implementation("com.android.tools.build:gradle:7.0.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10")
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -37,7 +37,7 @@ object Config {
     object BuildScriptPlugins {
         // https://developer.android.com/studio/releases/gradle-plugin
         // TODO: Update corresponding buildSrc/build.gradle.kts value when updating this version!
-        const val ANDROID_GRADLE = "com.android.tools.build:gradle:4.2.1"
+        const val ANDROID_GRADLE = "com.android.tools.build:gradle:7.0.0"
         const val KOTLIN_GRADLE = "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
 
         // Gradle version plugin; use dependencyUpdates task to view third party dependency updates via `./gradlew dependencyUpdates` or AS Gradle -> [project]] -> Tasks -> help -> dependencyUpdates
@@ -197,6 +197,7 @@ private object Libraries {
 
     // https://github.com/JakeWharton/timber/blob/master/CHANGELOG.md
     // https://github.com/JakeWharton/timber/releases
+    // TODO: Remove lint { disable "TIMBER-LINT-RULES" } from app AND data build.gradle.kts once Timber is updated past 4.7.1 to fix lint: https://github.com/JakeWharton/timber/issues/408
     const val TIMBER = "com.jakewharton.timber:timber:4.7.1"
 
     // https://github.com/JakeWharton/ProcessPhoenix/blob/master/CHANGELOG.md

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -16,26 +16,31 @@ jacoco {
 val apikey = ApiKeyProperties(System.getenv("APIKEY_PROPERTIES") ?: "apikey.properties", rootProject)
 
 android {
-    compileSdkVersion(Config.AndroidSdkVersions.COMPILE_SDK)
+    compileSdk = Config.AndroidSdkVersions.COMPILE_SDK
     buildToolsVersion = Config.AndroidSdkVersions.BUILD_TOOLS
 
     defaultConfig {
-        minSdkVersion(Config.AndroidSdkVersions.MIN_SDK)
-        targetSdkVersion(Config.AndroidSdkVersions.TARGET_SDK)
-        versionCode = BuildInfoManager.APP_VERSION.versionCode
-        versionName = BuildInfoManager.APP_VERSION.versionName
+        minSdk = Config.AndroidSdkVersions.MIN_SDK
+        targetSdk = Config.AndroidSdkVersions.TARGET_SDK
+        // As of AGP 7.0, versionName and versionCode have been removed from library modules: https://stackoverflow.com/a/67803541/201939
         buildConfigField("String", "BITBUCKET_KEY", apikey.key)
         buildConfigField("String", "BITBUCKET_SECRET", apikey.secret)
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
         isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
+    }
+    lint {
+        // TODO: Remove once Timber is updated past 4.7.1 with AGP 7.0.0 related lint fixes: https://github.com/JakeWharton/timber/issues/408
+        disable.addAll(
+            setOf("LogNotTimber", "StringFormatInTimber", "ThrowableNotAtBeginning", "BinaryOperationInTimber", "TimberArgCount", "TimberArgTypes", "TimberTagLength", "TimberExceptionLogging")
+        )
     }
 
     buildTypes {
@@ -82,12 +87,14 @@ private val internalDebugImplementation: Configuration by configurations.creatin
 private val internalDebugMiniImplementation: Configuration by configurations.creating { extendsFrom(configurations["debugImplementation"]) }
 private val internalReleaseImplementation: Configuration by configurations.creating { extendsFrom(configurations["releaseImplementation"]) }
 val productionReleaseImplementation: Configuration by configurations.creating { extendsFrom(configurations["releaseImplementation"]) }
+
 /** List of all buildable dev configurations */
 val devConfigurations: List<Configuration> = listOf(internalDebugImplementation, internalDebugMiniImplementation, internalReleaseImplementation)
 
 class ApiKeyProperties(pathToProperties: String, project: Project) {
     private val apikeyPropertiesFile = project.file(pathToProperties)
     private val apikeyProperties = Properties()
+
     init {
         apikeyProperties.load(FileInputStream(apikeyPropertiesFile))
     }


### PR DESCRIPTION
* Disable Timber lint rules for now due to an incompatibility between Timber 4.7.1 and AGP 7.0.0
* Remove `versionCode` and `versionName` from `:data` library module
* Update the syntax to set `compileSdkVersion`, `minSdkVersion` and `targetSdkVersion` in `:app` and `:data` `build.gradle.kts` files
    * Version suffix removed and directly set using = instead of passing as a function argument
* Update `sourceCompatibility`, `targetCompatibility`, and `jvmTarget` to reference java 11 instead of java 8 in `:app` and `:data` `build.gradle.kts` files
* Add new run configurations for `:app` and `:data` module unit tests using Gradle instead of Android JUnit. See https://developer.android.com/studio/releases#test-configurations