### PR TITLE
Bug fix: Use the `viewLifecycleOwner` instead of the fragment for the DataBinding `lifecycleOwner`

### DIFF
--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/BaseFragment.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/BaseFragment.kt
@@ -71,7 +71,7 @@ abstract class BaseFragment<FRAGMENT_VIEW_MODEL : BaseViewModel, BINDING : ViewD
      */
     @CallSuper
     open fun setupBinding(binding: BINDING) {
-        binding.lifecycleOwner = this
+        binding.lifecycleOwner = viewLifecycleOwner
         // In all layouts, the variable name should be "viewModel" for the given FRAGMENT_VIEW_MODEL
         binding.setVariable(BR.viewModel, fragmentViewModel)
     }


### PR DESCRIPTION
See https://developer.android.com/codelabs/kotlin-android-training-live-data-data-binding#4