### PR TITLE
Ensure that the app version name is not overridden for productionRelease CI builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ BuildInfoManager.initialize(
     BuildInfoInput(
         appVersion = AppVersion(major = 1, minor = 0, patch = 0, hotfix = 0, showEmptyPatchNumberInVersionName = true), // TODO: TEMPLATE - Replace with appropriate app version
         brandName = "BR_Architecture", // TODO: TEMPLATE - Replace with appropriate project brand name
-        productionReleaseVariantName = "release",
+        productionReleaseVariantName = "productionRelease",
         rootProjectDir = rootDir
     )
 )


### PR DESCRIPTION
Ex: Display `1.0.0` instead of `1.0.0-feature__update-version-name-and-apk-name-build-350-3d7f6b4-2020-05-14`