### PR TITLE
Rename app bundles following the same logic for apk renaming

### DIFF
--- a/.idea/runConfigurations/bundleInternalDebug.xml
+++ b/.idea/runConfigurations/bundleInternalDebug.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bundleInternalDebug" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="bundleInternalDebug" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/bundleProductionRelease_CI_test_w__fake_data.xml
+++ b/.idea/runConfigurations/bundleProductionRelease_CI_test_w__fake_data.xml
@@ -1,0 +1,33 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bundleProductionRelease CI test w/ fake data" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="BUILD_NUMBER" value="44332211" />
+          <entry key="IS_CI" value="true" />
+          <entry key="_KEYSTORE" value="../keystore/debug.keystore" />
+          <entry key="_KEYSTORE_PASSWORD" value="android" />
+          <entry key="_KEY_ALIAS" value="androiddebugkey" />
+          <entry key="_KEY_PASSWORD" value="android" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="bundleProductionRelease" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/bundleProductionRelease_non_CI_test_w__fake_data.xml
+++ b/.idea/runConfigurations/bundleProductionRelease_non_CI_test_w__fake_data.xml
@@ -1,0 +1,33 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="bundleProductionRelease non-CI test w/ fake data" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="BUILD_NUMBER" value="" />
+          <entry key="IS_CI" value="false" />
+          <entry key="_KEYSTORE" value="../keystore/debug.keystore" />
+          <entry key="_KEYSTORE_PASSWORD" value="android" />
+          <entry key="_KEY_ALIAS" value="androiddebugkey" />
+          <entry key="_KEY_PASSWORD" value="android" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="bundleProductionRelease" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
 extra.set("jacocoCoverageThreshold", 0.20.toBigDecimal()) // module specific code coverage verification threshold
 apply(from = "../jacocoModule.gradle")
 
+apply(from = "../renameAppBundle.gradle.kts") // configures additional gradle tasks to rename app bundles (when needed)
+
 // Prep BuildInfoManager to use its functions/properties later throughout this build script
 BuildInfoManager.initialize(
     BuildInfoInput(

--- a/buildSrc/src/main/kotlin/BuildInfoManager.kt
+++ b/buildSrc/src/main/kotlin/BuildInfoManager.kt
@@ -28,13 +28,15 @@ object BuildInfoManager {
     val APP_VERSION: AppVersion by lazy { input.appVersion }
 
     /** Build number set as an environment variable on the build server (or empty string for local builds) */
-    private val BUILD_NUMBER: String = System.getenv("BUILD_NUMBER").orEmpty()
+    private val BUILD_NUMBER: String
+        get() = System.getenv("BUILD_NUMBER").orEmpty() // using get() to allow value to be read dynamically if it was to change (primarily during local machine task execution testing)
 
     /** True if this build is running an a continuous integration server (ie, Jenkins). False if running on a local dev machine. */
-    private val IS_CI: Boolean = determineIfCi()
+    private val IS_CI: Boolean
+        get() = determineIfCi() // using get() to allow value to be read dynamically if it was to change (primarily during local machine task execution testing)
 
-    /** True if apk name should be overridden. Otherwise false */
-    private fun shouldOverrideApkName(): Boolean = IS_CI
+    /** True if apk/aab names should be overridden. Otherwise false */
+    fun shouldOverrideApkAndAabNames(): Boolean = IS_CI
     /** True if version name should be overridden. Otherwise false */
     private fun shouldOverrideVersionName(variantName: String): Boolean = IS_CI && !isProductionReleaseVariant(variantName)
 
@@ -43,6 +45,10 @@ object BuildInfoManager {
     fun initialize(buildInfoInput: BuildInfoInput) {
         if (!::input.isInitialized) {
             this.input = buildInfoInput
+            logBuildInfo()
+        } else {
+            // Likely occurs due to gradle buildCache causing this object to already be initialized
+            println("[initialize] already initialized")
             logBuildInfo()
         }
     }
@@ -65,7 +71,7 @@ object BuildInfoManager {
 
         // Don't change apk name for non-ci builds to prevent dynamic build configuration values slowing down dev machine builds.
         // See https://developer.android.com/studio/build/optimize-your-build#use_static_build_properties
-        if (shouldOverrideApkName()) {
+        if (shouldOverrideApkAndAabNames()) {
             apkVariantOutput.outputFileName = createApkFilename(variant.name)
         }
         // Don't change version name for prod release builds or local prod release builds
@@ -110,7 +116,28 @@ object BuildInfoManager {
      * * local release: app-release.apk
      */
     private fun createApkFilename(variantName: String): String {
-        return "${input.brandName}-$variantName-${gitBranchBuildNumberGitShaDateString()}.apk"
+        return createAppArtifactFilename(variantName, AppArtifact.Apk)
+    }
+
+    // TODO: TEMPLATE - Update CI debug and CI release brand name prefix values to match the updated BuildInfoInput.brandName value to show brand specific apk naming examples
+    /**
+     * Generates an aab filename with [BuildInfoInput.brandName], variant, build number, git sha, and date.
+     *
+     * **Intended to only be called for CI builds**. Using a dynamic value for aab name on dev builds slows down build time.
+     * See https://developer.android.com/studio/build/optimize-your-build#use_static_build_properties
+     *
+     * #### Examples
+     * * CI debug:      BR_Architecture-debug-feature__update-version-name-and-apk-name-build-350-3d7f6b4-2020-05-14.aab
+     * * CI release:    BR_Architecture-release-feature__update-version-name-and-apk-name-build-350-3d7f6b4-2020-05-14.aab
+     * * local debug:   app-debug.aab
+     * * local release: app-release.aab
+     */
+    fun createAabFilename(variantName: String): String {
+        return createAppArtifactFilename(variantName, AppArtifact.Aab)
+    }
+
+    private fun createAppArtifactFilename(variantName: String, appArtifact: AppArtifact): String {
+        return "${input.brandName}-$variantName-${gitBranchBuildNumberGitShaDateString()}${appArtifact.fileExtension}"
     }
 
     /**
@@ -180,5 +207,11 @@ object BuildInfoManager {
         } catch (e: IOException) {
             "<empty>"
         }
+    }
+
+    /** Post build app artifact generated from a successful build. */
+    private enum class AppArtifact(val fileExtension: String) {
+        Apk(".apk"),
+        Aab(".aab")
     }
 }

--- a/renameAppBundle.gradle.kts
+++ b/renameAppBundle.gradle.kts
@@ -7,10 +7,10 @@ if (BuildInfoManager.shouldOverrideApkAndAabNames()) {
     tasks.whenTaskAdded {
         val verboseLogging = false
         // Skip some unnecessary tasks
-        if (name.startsWith("bundle")
-            && !name.contains("Classes")
-            && !name.contains("Resources")
-            && name != "bundle"
+        if (name.startsWith("bundle") &&
+            !name.contains("Classes") &&
+            !name.contains("Resources") &&
+            name != "bundle"
         ) {
             val deletePreviouslyRenamedAabTaskName = "deletePreviouslyRenamed${name.capitalize()}Aab"
             val renameAabTaskName = "rename${name.capitalize()}Aab"
@@ -23,7 +23,7 @@ if (BuildInfoManager.shouldOverrideApkAndAabNames()) {
             val flavor = indexOfFlavor?.let { variant.substring(0, it) }
             val buildType = indexOfFlavor?.let { variant.substring(it).decapitalize() }
 
-            val aabFolderPath = "${buildDir}/outputs/bundle/${variant}/"
+            val aabFolderPath = "$buildDir/outputs/bundle/$variant/"
             val originalAabFilename = "app-$flavor-$buildType.aab"
             val updatedAabFilename = BuildInfoManager.createAabFilename(variant)
 

--- a/renameAppBundle.gradle.kts
+++ b/renameAppBundle.gradle.kts
@@ -1,0 +1,73 @@
+/**
+ * Renames app bundle to value specified in BuildInfoManager.createAabFilename(...) when `BuildInfoManager.shouldOverrideApkAndAabNames()` is true
+ * Expected to be included in non-library android modules (likely just :app) via: `apply(from = "../renameAppBundle.gradle.kts")`
+ * Inspiration from https://stackoverflow.com/a/69305535/201939 and https://stackoverflow.com/a/54010142/201939
+ */
+if (BuildInfoManager.shouldOverrideApkAndAabNames()) {
+    tasks.whenTaskAdded {
+        val verboseLogging = false
+        // Skip some unnecessary tasks
+        if (name.startsWith("bundle")
+            && !name.contains("Classes")
+            && !name.contains("Resources")
+            && name != "bundle"
+        ) {
+            val deletePreviouslyRenamedAabTaskName = "deletePreviouslyRenamed${name.capitalize()}Aab"
+            val renameAabTaskName = "rename${name.capitalize()}Aab"
+            val deleteOriginalAabTaskName = "deleteOriginal${name.capitalize()}Aab"
+
+            // Quick and dirty way to derive variant name from the current bundleVARIANT task name.
+            val variant = name.substring("bundle".length).decapitalize()
+            // Quick and dirty way to derive the buildType and flavor from the variant
+            val indexOfFlavor = variant.indexOfFirst { it.isUpperCase() }.takeIf { it != -1 }
+            val flavor = indexOfFlavor?.let { variant.substring(0, it) }
+            val buildType = indexOfFlavor?.let { variant.substring(it).decapitalize() }
+
+            val aabFolderPath = "${buildDir}/outputs/bundle/${variant}/"
+            val originalAabFilename = "app-$flavor-$buildType.aab"
+            val updatedAabFilename = BuildInfoManager.createAabFilename(variant)
+
+            if (flavor != null && buildType != null && variant.isNotBlank()) {
+                if (verboseLogging) {
+                    println("[renameAab] flavor=$flavor")
+                    println("[renameAab] buildType=$buildType")
+                    println("[renameAab] variant=$variant")
+                    println("[renameAab] aabFolderPath=$aabFolderPath")
+                    println("[renameAab] originalAabFilename=$originalAabFilename")
+                    println("[renameAab] updatedAabFilename=$updatedAabFilename")
+                }
+
+                // Cleans up any existing aab file with matching name to allow the future copy-rename task to succeed
+                tasks.register<Delete>(deletePreviouslyRenamedAabTaskName) {
+                    delete("$aabFolderPath/$updatedAabFilename")
+                    doLast {
+                        println("[deletePreviouslyRenamedAab] delete previously renamed bundle task completed - updatedAabFilename=$updatedAabFilename")
+                    }
+                }
+
+                // Copy-renames the aab file from the original name to the new name
+                tasks.register<Copy>(renameAabTaskName) {
+                    dependsOn(deletePreviouslyRenamedAabTaskName)
+                    from(aabFolderPath)
+                    setDestinationDir(file(aabFolderPath))
+                    rename(originalAabFilename, updatedAabFilename)
+                    doLast {
+                        println("[renameAab] rename bundle task completed - updatedAabFilename$updatedAabFilename")
+                    }
+                }
+
+                // Cleans up the original aab file to prevent multiple aabs being present in the folder
+                tasks.register<Delete>(deleteOriginalAabTaskName) {
+                    dependsOn(renameAabTaskName)
+
+                    delete("$aabFolderPath/$originalAabFilename")
+                    doLast {
+                        println("[deleteOriginalAab] delete original bundle task completed - originalAabFilename=$originalAabFilename")
+                    }
+                }
+
+                finalizedBy(deletePreviouslyRenamedAabTaskName, renameAabTaskName, deleteOriginalAabTaskName)
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Add renameAppBundle.gradle.kts file that adds logic to effectively rename app bundles. Using a separate file to prevent cluttering the `app` module `build.gradle.kts`.
* Check in several `bundle...` Android Studio Run Configurations to allow quick testing/verification of CI and non-CI bundle renaming logic.
* Refactor IS_CI and BUILD_NUMBER to be implemented by overriding their getters instead of using initializers to allow the values to be dynamically computed on each access. This was needed when performing local testing by switching between CI and non-CI environments without performing a clean and cleanBuildCache.