### PR TITLE
Remove abandoned debug db dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,13 +131,7 @@ android {
     }
 }
 
-// Declare configurations per variant to use in the dependencies block below. More info: https://guides.gradle.org/migrating-build-logic-from-groovy-to-kotlin/#custom_configurations_and_dependencies
-private val internalDebugImplementation: Configuration by configurations.creating { extendsFrom(configurations["debugImplementation"]) }
-private val internalDebugMiniImplementation: Configuration by configurations.creating { extendsFrom(configurations["debugImplementation"]) }
-private val internalReleaseImplementation: Configuration by configurations.creating { extendsFrom(configurations["releaseImplementation"]) }
-val productionReleaseImplementation: Configuration by configurations.creating { extendsFrom(configurations["releaseImplementation"]) }
-/** List of all buildable dev configurations */
-val devConfigurations: List<Configuration> = listOf(internalDebugImplementation, internalDebugMiniImplementation, internalReleaseImplementation)
+// Declare configurations per variant to use in the dependencies block below. See :data module for examples if needed here in the :app module.
 
 dependencies {
     implementation(project(mapOf("path" to ":data")))
@@ -171,7 +165,6 @@ dependencies {
     timberDependencies()
     processPhoenixDependencies()
     leakCanaryDependencies()
-    debugDatabaseDependencies(devConfigurations = devConfigurations)
 
     // Test
     junitDependencies()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -276,11 +276,6 @@ private object Libraries {
     private const val CHUCKER_VERSION = "3.5.2"
     const val CHUCKER = "com.github.ChuckerTeam.Chucker:library:$CHUCKER_VERSION"
     const val CHUCKER_NO_OP = "com.github.ChuckerTeam.Chucker:library-no-op:$CHUCKER_VERSION"
-
-    // https://github.com/amitshekhariitbhu/Android-Debug-Database/blob/master/CHANGELOG.md
-    // https://github.com/amitshekhariitbhu/Android-Debug-Database/releases
-    // Using jitpack: https://github.com/amitshekhariitbhu/Android-Debug-Database/issues/208
-    const val DEBUG_DATABASE = "com.github.amitshekhariitbhu.Android-Debug-Database:debug-db:v1.0.6"
 }
 
 /**
@@ -441,12 +436,6 @@ fun DependencyHandler.chuckerDependencies(devConfigurations: List<Configuration>
     add(productionConfiguration.name, Libraries.CHUCKER_NO_OP) // note the releaseImplementation no-op
 }
 
-fun DependencyHandler.debugDatabaseDependencies(devConfigurations: List<Configuration>) {
-    // Only add dependency for dev configurations in the list
-    devConfigurations.forEach { devConfiguration: Configuration ->
-        add(devConfiguration.name, Libraries.DEBUG_DATABASE)
-    }
-}
 
 // Test specific dependency groups
 fun DependencyHandler.junitDependencies() {

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -246,12 +246,11 @@ Takeaways:
 
 ## Miscellaneous
 
-### View/Edit local database/shared prefs
-The [Android Debug Database](https://github.com/amitshekhariitbhu/Android-Debug-Database) non-prod dependency allows easy viewing of the internal app database/shared prefs. To view in your browser, do the following things:
+### Viewing/Editing shared preferences (using AS Device File Explorer)
+See https://stackoverflow.com/a/52352741/201939 as well as comments to see how to save as/upload edits on top of the original files.
 
-1. Connect an emulator/device and execute the following: `adb forward tcp:8080 tcp:8080` (or run the `Prep DebugDb adb connection` Android Studio Run Configuration to execute it)
-    1. For an emulator, open [http://localhost:8080/](http://localhost:8080/) (or run the `Open emu DebugDg Web Portal` Android Studio Run Configuration to launch it)
-    2. For a device, filter logcat by debugdb or keep an eye out for `D/DebugDB: Open http://XXX.XXX.X.XXX:8080 in your browser` and click/copy-paste the link in your browser.
+### Inspect/Query/Modify databases (using AS App Inspection / Database Inspector on api 26+ device/emulator)
+See https://developer.android.com/studio/inspect/database
 
 ### Counting lines of code (using [cloc][cloc])
 * Install using homebrew: `brew install cloc` (or your package manager of choice: https://github.com/AlDanial/cloc#install-via-package-manager)

--- a/scripts/open_emu_debug_db_web_portal.sh
+++ b/scripts/open_emu_debug_db_web_portal.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# The purpose of this script is to allow an Android Studio Run Configuration to be created to execute the following command to open the debugdb ui for the emulator. See BEST_PRACTICES.md for more info.
-
-open http://localhost:8080/

--- a/scripts/prep_debug_db_adb_connection.sh
+++ b/scripts/prep_debug_db_adb_connection.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# The purpose of this script is to allow an Android Studio Run Configuration to be created to execute the following command to prepare the Android DebugDb connection. See BEST_PRACTICES.md for more info.
-
-adb forward tcp:8080 tcp:8080


### PR DESCRIPTION
Android Studio now natively support database inspection as well as the ability to view/update SharedPreferences so this library is no longer as helpful as it used to be. `BEST_PRACTICES.md` has been updated with additional information on how to do these things.