### PR TITLE
Add `StringIdHelper` and inject `Clock` to better support testability

### DIFF
--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/HeaderViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/HeaderViewModel.kt
@@ -1,11 +1,11 @@
 package com.bottlerocketstudios.brarchitecture.ui
 
-import androidx.annotation.StringRes
 import androidx.databinding.ViewDataBinding
 import com.bottlerocketstudios.brarchitecture.R
+import com.bottlerocketstudios.brarchitecture.ui.util.StringIdHelper
 import com.xwray.groupie.viewbinding.BindableItem
 
-data class HeaderViewModel(@StringRes val text: Int) : DbViewModel, BaseBindableViewModel() {
+data class HeaderViewModel(val text: StringIdHelper) : DbViewModel, BaseBindableViewModel() {
     override fun getItemFactory(): (BaseBindableViewModel) -> BindableItem<ViewDataBinding> {
         return { vm -> ViewModelItem(vm as HeaderViewModel, R.layout.item_header) }
     }

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/bindingadapters/TextViewBindingAdapters.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/bindingadapters/TextViewBindingAdapters.kt
@@ -1,0 +1,10 @@
+package com.bottlerocketstudios.brarchitecture.ui.bindingadapters
+
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+import com.bottlerocketstudios.brarchitecture.ui.util.StringIdHelper
+
+@BindingAdapter("textByStringIdHelper")
+fun TextView.textByStringIdHelper(stringIdHelper: StringIdHelper?) {
+    text = stringIdHelper?.getString(context)
+}

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.Dispatche
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
 import com.bottlerocketstudios.brarchitecture.ui.HeaderViewModel
 import com.bottlerocketstudios.brarchitecture.ui.repository.RepositoryViewModel
+import com.bottlerocketstudios.brarchitecture.ui.util.StringIdHelper
 import com.xwray.groupie.Section
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -22,7 +23,7 @@ class HomeViewModel(repo: BitbucketRepository, private val dispatcherProvider: D
             repos.collect { repoList ->
                 val map = repoList.map { RepositoryViewModel(it) }
                 withContext(dispatcherProvider.Main) {
-                    reposGroup.setHeader(HeaderViewModel(R.string.home_repositories))
+                    reposGroup.setHeader(HeaderViewModel(StringIdHelper.Id(R.string.home_repositories)))
                     reposGroup.update(map)
                 }
             }

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryViewModel.kt
@@ -1,20 +1,21 @@
 package com.bottlerocketstudios.brarchitecture.ui.repository
 
-import android.content.Context
 import androidx.databinding.ViewDataBinding
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.model.Repository
 import com.bottlerocketstudios.brarchitecture.ui.BaseBindableViewModel
 import com.bottlerocketstudios.brarchitecture.ui.DbViewModel
 import com.bottlerocketstudios.brarchitecture.ui.ViewModelItem
+import com.bottlerocketstudios.brarchitecture.ui.util.StringIdHelper
 import com.bottlerocketstudios.brarchitecture.ui.util.formattedUpdateTime
 import com.xwray.groupie.viewbinding.BindableItem
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.time.Clock
 
 data class RepositoryViewModel(val repository: Repository) : DbViewModel, KoinComponent, BaseBindableViewModel() {
-    private val context by inject<Context>()
-    val formattedUpdateTime = repository.updated.formattedUpdateTime(context)
+    private val clock by inject<Clock>()
+    val formattedUpdateTime: StringIdHelper = repository.updated.formattedUpdateTime(clock)
 
     override fun getItemFactory(): (BaseBindableViewModel) -> BindableItem<ViewDataBinding> {
         return { vm -> ViewModelItem(vm as RepositoryViewModel, R.layout.item_repository) }

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/snippet/SnippetViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/snippet/SnippetViewModel.kt
@@ -1,20 +1,21 @@
 package com.bottlerocketstudios.brarchitecture.ui.snippet
 
-import android.content.Context
 import androidx.databinding.ViewDataBinding
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.model.Snippet
 import com.bottlerocketstudios.brarchitecture.ui.BaseBindableViewModel
 import com.bottlerocketstudios.brarchitecture.ui.DbViewModel
 import com.bottlerocketstudios.brarchitecture.ui.ViewModelItem
+import com.bottlerocketstudios.brarchitecture.ui.util.StringIdHelper
 import com.bottlerocketstudios.brarchitecture.ui.util.formattedUpdateTime
 import com.xwray.groupie.viewbinding.BindableItem
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.time.Clock
 
 data class SnippetViewModel(val snippet: Snippet) : DbViewModel, KoinComponent, BaseBindableViewModel() {
-    private val context by inject<Context>()
-    val formattedUpdateTime = snippet.updated.formattedUpdateTime(context)
+    private val clock by inject<Clock>()
+    val formattedUpdateTime: StringIdHelper = snippet.updated.formattedUpdateTime(clock)
 
     override fun getItemFactory(): (BaseBindableViewModel) -> BindableItem<ViewDataBinding> {
         return { vm -> ViewModelItem(vm as SnippetViewModel, R.layout.item_snippet) }

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/util/DateTimeUtils.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/util/DateTimeUtils.kt
@@ -1,18 +1,18 @@
 package com.bottlerocketstudios.brarchitecture.ui.util
 
-import android.content.Context
 import com.bottlerocketstudios.brarchitecture.R
+import java.time.Clock
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
-fun ZonedDateTime?.formattedUpdateTime(context: Context): String {
-    val wasUpdated = this ?: ZonedDateTime.now()
-    val daysAgo = wasUpdated.until(ZonedDateTime.now(), ChronoUnit.DAYS).toInt()
+fun ZonedDateTime?.formattedUpdateTime(clock: Clock): StringIdHelper {
+    val wasUpdated = this ?: ZonedDateTime.now(clock)
+    val daysAgo = wasUpdated.until(ZonedDateTime.now(clock), ChronoUnit.DAYS).toInt()
     return when {
-        daysAgo == 0 -> context.getString(R.string.today)
-        daysAgo < ONE_WEEK_IN_DAYS -> context.resources.getQuantityString(R.plurals.days_ago_plural, daysAgo, daysAgo)
-        else -> wasUpdated.format(DateTimeFormatter.ISO_DATE)
+        daysAgo == 0 -> StringIdHelper.Id(R.string.today)
+        daysAgo < ONE_WEEK_IN_DAYS -> StringIdHelper.Plural(R.plurals.days_ago_plural, daysAgo, listOf(daysAgo))
+        else -> wasUpdated.format(DateTimeFormatter.ISO_LOCAL_DATE).toStringIdHelper()
     }
 }
 

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/util/StringIdHelper.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/util/StringIdHelper.kt
@@ -1,0 +1,65 @@
+package com.bottlerocketstudios.brarchitecture.ui.util
+
+import android.content.Context
+import androidx.annotation.PluralsRes
+import androidx.annotation.StringRes
+import com.bottlerocketstudios.brarchitecture.data.model.DomainModel
+import java.io.Serializable
+
+/**
+ * Union type that represents either the int ID, the format string, or the raw String.
+ *
+ * Calling getString resolves to a String from any subtype.
+ */
+sealed class StringIdHelper : DomainModel, Serializable {
+    data class Id(@StringRes val idRes: Int) : StringIdHelper()
+
+    data class Raw(val rawString: String) : StringIdHelper()
+
+    data class Format(@StringRes val idRes: Int, val formatArgs: List<Any>) : StringIdHelper()
+
+    data class Plural(@PluralsRes val idRes: Int, val quantity: Int, val formatArgs: List<Any>) : StringIdHelper()
+
+    fun getString(context: Context): String {
+        return when (this) {
+            is Id -> {
+                context.getString(idRes)
+            }
+            is Raw -> {
+                rawString
+            }
+            is Format -> {
+                val mappedArgs = formatArgs.map {
+                    // Allow for the use of string helpers within format args by unwrapping them here
+                    if (it is StringIdHelper) {
+                        it.getString(context)
+                    } else {
+                        it
+                    }
+                }
+                @Suppress("SpreadOperator")
+                context.getString(idRes, *mappedArgs.toTypedArray())
+            }
+            is Plural -> {
+                val mappedArgs = formatArgs.map {
+                    // Allow for the use of string helpers within format args by unwrapping them here
+                    if (it is StringIdHelper) {
+                        it.getString(context)
+                    } else {
+                        it
+                    }
+                }
+                @Suppress("SpreadOperator")
+                context.resources.getQuantityString(idRes, quantity, *mappedArgs.toTypedArray())
+            }
+        }
+    }
+
+    companion object {
+        const val serialVersionUID = 1L
+    }
+}
+
+fun String.toStringIdHelper() = StringIdHelper.Raw(
+    rawString = this
+)

--- a/app/src/main/res/layout/item_header.xml
+++ b/app/src/main/res/layout/item_header.xml
@@ -23,7 +23,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"
             android:layout_marginStart="8dp"
-            android:text="@{dbViewModel.text}"
+            app:textByStringIdHelper="@{dbViewModel.text}"
             tools:text="REPOSITORIES"
             />
 

--- a/app/src/main/res/layout/item_repository.xml
+++ b/app/src/main/res/layout/item_repository.xml
@@ -80,7 +80,7 @@
                 android:layout_marginEnd="20dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@id/name"
-                android:text="@{dbViewModel.formattedUpdateTime}"
+                app:textByStringIdHelper="@{dbViewModel.formattedUpdateTime}"
                 tools:text="Repository description"
                 />
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_snippet.xml
+++ b/app/src/main/res/layout/item_snippet.xml
@@ -67,7 +67,7 @@
                 android:layout_marginEnd="20dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@id/name"
-                android:text="@{dbViewModel.formattedUpdateTime}"
+                app:textByStringIdHelper="@{dbViewModel.formattedUpdateTime}"
                 tools:text="5 days ago"
                 />
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,11 @@
     </plurals>
     <string name="today">Today</string>
 
+    <!-- Values added to exercise unit tests -->
+    <string name="sample_format">Sample %1$s</string>
+    <plurals name="sample_plural_format">
+        <item quantity="one">%1$s was updated %2$d day ago</item>
+        <item quantity="other">%1$s was updated %2$d days ago</item>
+    </plurals>
+
 </resources>

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/TestModule.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/TestModule.kt
@@ -3,11 +3,13 @@ package com.bottlerocketstudios.brarchitecture.test
 import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.test.mocks.testContext
 import org.koin.dsl.module
+import java.time.Clock
 
 object TestModule {
     // Default mocks can be overridden using inlineKoinSingle function
     fun generateMockedTestModule() = module {
         single { testContext }
         single<DispatcherProvider> { TestDispatcherProvider() }
+        single<Clock> { Clock.systemDefaultZone() }
     }
 }

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/mocks/MockAndroidObjects.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/mocks/MockAndroidObjects.kt
@@ -12,6 +12,30 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 
+val testResources: Resources = mock {
+    // Order is important here, most generic match first. Last match is final value.
+    on { getQuantityString(any(), any(), anyVararg()) } doReturn ""
+    on { getDrawable(any()) } doReturn null
+    on { getDrawable(any(), any()) } doReturn null
+    on { getString(any(), anyVararg()) } doReturn ""
+
+    // Add specific mocks for getString/getQuantity/etc string/plural/etc references and mocked values here
+    on { getQuantityString(eq(R.plurals.days_ago_plural), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()) } doAnswer {
+        if (it.getArgument<Int>(1) == 1) {
+            "${it.getArgument<Int>(1)} day ago"
+        } else {
+            "${it.getArgument<Int>(2)} days ago"
+        }
+    }
+    on { getQuantityString(eq(R.plurals.sample_plural_format), ArgumentMatchers.anyInt(), ArgumentMatchers.anyString(), ArgumentMatchers.anyInt()) } doAnswer {
+        if (it.getArgument<Int>(1) == 1) {
+            "${it.getArgument<Int>(2)} was updated ${it.getArgument<Int>(3)} day ago"
+        } else {
+            "${it.getArgument<Int>(2)} was updated ${it.getArgument<Int>(3)} days ago"
+        }
+    }
+}
+
 val testContext: Context = mock {
     // Order is important here, most generic match first. Last match is final value.
     on { getString(any()) } doReturn ""
@@ -21,22 +45,9 @@ val testContext: Context = mock {
 
     // Add specific mocks for getString/getQuantity/etc string/plural/etc references and mocked values here
     on { getString(R.string.today) } doReturn "Today"
-}
-
-val testResources: Resources = mock {
-    // Order is important here, most generic match first. Last match is final value.
-    on { getQuantityString(any(), any(), any()) } doReturn ""
-    on { getDrawable(any()) } doReturn null
-    on { getDrawable(any(), any()) } doReturn null
-    on { getString(any(), anyVararg()) } doReturn ""
-    // Add specific mocks for getString/getQuantity/etc string/plural/etc references and mocked values here
-
-    on { getQuantityString(eq(R.plurals.days_ago_plural), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()) } doAnswer {
-        if (it.getArgument<Int>(1) == 1) {
-            "${it.getArgument<Int>(1)} day ago"
-        } else {
-            "${it.getArgument<Int>(2)} days ago"
-        }
+    on { getString(R.string.app_name) } doReturn "App Name"
+    on { getString(eq(R.string.sample_format), ArgumentMatchers.anyString()) } doAnswer {
+        "Sample ${it.getArgument<String>(1)}"
     }
 }
 

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/util/DateTimeUtilsKtTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/util/DateTimeUtilsKtTest.kt
@@ -1,0 +1,116 @@
+package com.bottlerocketstudios.brarchitecture.ui.util
+
+import com.bottlerocketstudios.brarchitecture.R
+import com.bottlerocketstudios.brarchitecture.test.BaseTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class DateTimeUtilsKtTest : BaseTest() {
+
+    @Test
+    fun formattedUpdateTime_nullInput_returnsTodayOutput() {
+        val fixedClock = Clock.fixed(
+            Instant.parse("2022-01-26T13:00:00.00Z"),
+            ZoneId.of("UTC"),
+        )
+        val sut: ZonedDateTime? = null
+
+        val result = sut.formattedUpdateTime(fixedClock)
+
+        assertThat(result).isEqualTo(StringIdHelper.Id(R.string.today))
+    }
+
+    @Test
+    fun formattedUpdateTime_sameDay_returnsTodayOutput() {
+        val fixedClock = Clock.fixed(
+            Instant.parse("2022-01-26T13:00:00.00Z"),
+            ZoneId.of("UTC"),
+        )
+        val sut = ZonedDateTime.now(
+            Clock.fixed(
+                Instant.parse("2022-01-26T08:00:00.00Z"),
+                ZoneId.of("UTC"),
+            )
+        )
+
+        val result = sut.formattedUpdateTime(fixedClock)
+
+        assertThat(result).isEqualTo(StringIdHelper.Id(R.string.today))
+    }
+
+    @Test
+    fun formattedUpdateTime_oneDayAgo_returnsAppropriatePluralString() {
+        val fixedClock = Clock.fixed(
+            Instant.parse("2022-01-26T13:00:00.00Z"),
+            ZoneId.of("UTC"),
+        )
+        val sut = ZonedDateTime.now(
+            Clock.fixed(
+                Instant.parse("2022-01-25T08:00:00.00Z"),
+                ZoneId.of("UTC"),
+            )
+        )
+
+        val result = sut.formattedUpdateTime(fixedClock)
+
+        assertThat(result).isEqualTo(StringIdHelper.Plural(R.plurals.days_ago_plural, 1, listOf(1)))
+    }
+
+    @Test
+    fun formattedUpdateTime_sixDaysAgo_returnsAppropriatePluralString() {
+        val fixedClock = Clock.fixed(
+            Instant.parse("2022-01-26T13:00:00.00Z"),
+            ZoneId.of("UTC"),
+        )
+        val sut = ZonedDateTime.now(
+            Clock.fixed(
+                Instant.parse("2022-01-20T08:00:00.00Z"),
+                ZoneId.of("UTC"),
+            )
+        )
+
+        val result = sut.formattedUpdateTime(fixedClock)
+
+        assertThat(result).isEqualTo(StringIdHelper.Plural(R.plurals.days_ago_plural, 6, listOf(6)))
+    }
+
+    @Test
+    fun formattedUpdateTime_sevenDaysAgo_returnsFormattedDateTime() {
+        val fixedClock = Clock.fixed(
+            Instant.parse("2022-01-26T05:00:00.00Z"),
+            ZoneId.of("UTC"),
+        )
+        val sut = ZonedDateTime.now(
+            Clock.fixed(
+                Instant.parse("2022-01-19T05:00:00.00Z"),
+                ZoneId.of("UTC"),
+            )
+        )
+
+        val result = sut.formattedUpdateTime(fixedClock)
+
+        assertThat(result).isEqualTo("2022-01-19".toStringIdHelper())
+    }
+
+    @Test
+    fun formattedUpdateTime_sevenDaysAgoAltTimezone_returnsFormattedDateTimeForTimeZone() {
+        val fixedClock = Clock.fixed(
+            Instant.parse("2022-01-26T05:00:00.00Z"),
+            ZoneId.of("UTC"),
+        )
+        val sut = ZonedDateTime.now(
+            Clock.fixed(
+                Instant.parse("2022-01-19T05:00:00.00Z"),
+                ZoneId.of("America/Chicago"),
+            )
+        )
+
+        val result = sut.formattedUpdateTime(fixedClock)
+
+        assertThat(result).isEqualTo("2022-01-18".toStringIdHelper())
+    }
+}

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/util/StringIdHelperTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/util/StringIdHelperTest.kt
@@ -1,0 +1,66 @@
+package com.bottlerocketstudios.brarchitecture.ui.util
+
+import com.bottlerocketstudios.brarchitecture.R
+import com.bottlerocketstudios.brarchitecture.test.BaseTest
+import com.bottlerocketstudios.brarchitecture.test.mocks.testContext
+import com.google.common.truth.Truth.assertThat
+
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class StringIdHelperTest : BaseTest() {
+
+    @Test
+    fun getString_raw_returnsRawString() {
+        val sut = StringIdHelper.Raw("foo")
+
+        val result = sut.getString(mock())
+
+        assertThat(result).isEqualTo("foo")
+    }
+
+    @Test
+    fun getString_id_returnsMatchingIdString() {
+        val sut = StringIdHelper.Id(R.string.app_name)
+
+        val result = sut.getString(testContext)
+
+        assertThat(result).isEqualTo("App Name")
+    }
+
+    @Test
+    fun getString_formatWithStringArgs_returnsFormattedString() {
+        val sut = StringIdHelper.Format(R.string.sample_format, listOf("Foo"))
+
+        val result = sut.getString(testContext)
+
+        assertThat(result).isEqualTo("Sample Foo")
+    }
+
+    @Test
+    fun getString_formatWithStringIdHelperArgs_returnsFormattedString() {
+        val sut = StringIdHelper.Format(R.string.sample_format, listOf(StringIdHelper.Id(R.string.app_name)))
+
+        val result = sut.getString(testContext)
+
+        assertThat(result).isEqualTo("Sample App Name")
+    }
+
+    @Test
+    fun getString_pluralWithStringArgs_returnsFormattedString() {
+        val sut = StringIdHelper.Plural(R.plurals.days_ago_plural, 10, listOf(10))
+
+        val result = sut.getString(testContext)
+
+        assertThat(result).isEqualTo("10 days ago")
+    }
+
+    @Test
+    fun getString_pluralWithStringIdHelperArgs_returnsFormattedString() {
+        val sut = StringIdHelper.Plural(R.plurals.sample_plural_format, 10, listOf("Foo".toStringIdHelper(), 10))
+
+        val result = sut.getString(testContext)
+
+        assertThat(result).isEqualTo("Foo was updated 10 days ago")
+    }
+}

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/di/DataModules.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/di/DataModules.kt
@@ -27,12 +27,15 @@ import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
+import java.time.Clock
 
 /** General app configuration (repositories/viewmodels/etc) */
 object DataModule {
     val module = module {
+        // Clock for injectable time that can be replaced in tests
+        single<Clock> { Clock.systemDefaultZone() }
         single<DispatcherProvider> { DispatcherProviderImpl() }
-        single<Moshi> { Moshi.Builder().add(DateTimeAdapter()).build() }
+        single<Moshi> { Moshi.Builder().add(DateTimeAdapter(clock = get())).build() }
         single<BitbucketRepository> { BitbucketRepositoryImpl(bitbucketService = get(), bitbucketCredentialsRepository = get(), responseToApiResultMapper = get()) }
         single<EnvironmentRepository> { EnvironmentRepositoryImpl(sharedPrefs = get(named(KoinNamedSharedPreferences.Environment)), buildConfigProvider = get()) }
         single<ForceCrashLogic> { ForceCrashLogicImpl(buildConfigProvider = get()) }

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/repository/DateTimeAdapter.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/repository/DateTimeAdapter.kt
@@ -3,10 +3,11 @@ package com.bottlerocketstudios.brarchitecture.data.repository
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import timber.log.Timber
+import java.time.Clock
 import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException
 
-class DateTimeAdapter {
+class DateTimeAdapter(private val clock: Clock) {
     @ToJson
     fun toJson(zonedDateTime: ZonedDateTime) = zonedDateTime.toString()
 
@@ -16,7 +17,7 @@ class DateTimeAdapter {
             ZonedDateTime.parse(zonedDateTime)
         } catch (exception: DateTimeParseException) {
             Timber.e(exception, "Failed to parse zonedDateTime")
-            ZonedDateTime.now()
+            ZonedDateTime.now(clock)
         }
     }
 }

--- a/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/network/BitbucketServiceTest.kt
+++ b/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/network/BitbucketServiceTest.kt
@@ -104,7 +104,7 @@ class BitbucketServiceTest : BaseTest() {
             .baseUrl("https://api.bitbucket.org")
             .client(okHttpClient)
             .addConverterFactory(ScalarsConverterFactory.create())
-            .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder().add(DateTimeAdapter()).build()))
+            .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder().add(DateTimeAdapter(mock())).build()))
             .build()
 
         return retrofit.create(BitbucketService::class.java)

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -131,6 +131,12 @@ It is a good practice to add the appropriate Time Unit suffix to methods, parame
 
 If using a type that abstracts the need for a unit such as `org.threeten.bp.Duration`, then you don't need to specify a suffix on that object. If you pull out the ms value of the duration as a variable, then add the suffix.
 
+## Use `StringIdHelper` to avoid depending on `Context` 
+Use `StringIdHelper.*` types (representing string resources, format strings, and plurals as well as raw strings) in `ViewModel`s (or other classes) to avoid needing a `Context`. This allows for **simpler unit testing** and **prevents the need for `Context` in places it shouldn't be used** by pushing the resolution of the final String to the view layer (using the `textByStringIdHelper` DataBinding custom BindingAdapter function that takes in a `Context`).
+
+## Inject `Clock`
+Pass the `java.time.Clock` instance from Koin to any java 8 date/time apis that can use it in order **to allow control of the clock in unit tests**. This will typically be the `.now(clock: Clock)` api on `Instant`, `ZonedDateTime`, `LocalDateTime`, `LocalDate`, `LocalTime`, and so on.
+
 ## Jacoco
 1. **Generate a combined jacoco report of all modules (as well as a report per module)** by executing the `testInternalDebugCombinedUnitTestCoverage` gradle task (or included Android Studio Run Configuration). More info in [jacocoRoot.gradle](../jacocoRoot.gradle)
     * **View the generated reports** by executing the `Open Jacoco Report - internalDebug` Android Studio Run configuration, manually executing `open_jacoco_report_internalDebug.sh`, or manually opening the index.html files from the reports directories.


### PR DESCRIPTION
### Use `StringIdHelper` to avoid depending on `Context`
Use `StringIdHelper.*` types (representing string resources, format strings, and plurals as well as raw strings) in `ViewModel`s (or other classes) to avoid needing a `Context`. This allows for **simpler unit testing** and **prevents the need for `Context` in places it shouldn't be used** by pushing the resolution of the final String to the view layer (using the `textByStringIdHelper` DataBinding custom BindingAdapter function that takes in a `Context`).

### Inject `Clock`
Pass the `java.time.Clock` instance from Koin to any java 8 date/time apis that can use it in order **to allow control of the clock in unit tests**. This will typically be the `.now(clock: Clock)` api on `Instant`, `ZonedDateTime`, `LocalDateTime`, `LocalDate`, `LocalTime`, and so on.

### DateTimeFormatter change
Using the `DateTimeFormatter.ISO_LOCAL_DATE` formatter instead of `DateTimeFormatter.ISO_DATE` to prevent showing a date with `Z` or `-06:00` in the last updated date UI.

### Additional Unit Tests
Add unit tests for `DateTimeUtils` (controlling the clock for easy testing).

### Documentation
Update `BEST_PRACTICES.md` with entries for `StringIdHelper` and injecting the Clock.