### PR TITLE
Add clarification about `FIXME`s that should be checked every dev signoff

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -21,7 +21,7 @@
 #-renamesourcefileattribute SourceFile
 
 ## For more info, see https://www.guardsquare.com/en/products/proguard/manual/usage#obfuscationoptions
-## FIXME: Below line must be commented out! Only uncomment to aid in debugging certain proguard related crashes to better help identify the source of the crash
+## FIXME - VALIDATE EVERY DEV SIGNOFF: Below line must be commented out! Only uncomment to aid in debugging certain proguard related crashes to better help identify the source of the crash
 #-dontobfuscate
 
 # General proguard directives

--- a/app/src/internal/res/xml/network_security_config.xml
+++ b/app/src/internal/res/xml/network_security_config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- FIXME: DEV SIGNOFF - Verify that the play store build is NOT proxyable on 24+ devices. -->
+<!-- FIXME - VALIDATE EVERY DEV SIGNOFF: Verify that the play store build is NOT proxyable on 24+ devices. -->
 <!-- NOTE: This configuration is present to allow proxying of 24+ devices on all internal flavor builds, including internalRelease builds (for QA purposes) -->
 <!-- More info at https://developer.android.com/training/articles/security-config.html -->
 <network-security-config xmlns:tools="http://schemas.android.com/tools">

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -120,6 +120,8 @@ sealed class Foo {
 * Use `FIXME` comments to leave "breadcrumbs" in cases where some specific code or condition needs to be revisited **before the next release**. You might leave a FIXME when using a placeholder value that needs to be updated with the real one later on down the road when it is created/obtained. During dev signoff, all FIXME entries should be evaluated and handled appropriately.
     * `// FIXME: Replace with production value from client before release!`
     * `// FIXME: Set to BuildConfig.DEBUG before release!`
+* Use `FIXME - VALIDATE EVERY DEV SIGNOFF` to validate the condition before every dev signoff. These comments should likely never be removed as long as the commented scenario is still valid to check every dev signoff.
+    * `FIXME - VALIDATE EVERY DEV SIGNOFF: Verify that the play store build is NOT proxyable on 24+ devices.`
 * Use `TODO` comments to leave "breadcrumbs" of ideas to improve the codebase. You might call out code that you write that could be done in a more optimal way in the future. Or you could leave a TODO for some code that you see that could be improved but you aren't able to immediately act on it right then.
     * `// TODO: TODO: Consider breaking this up into smaller mappers if the scope becomes too large`
     * `// TODO: Remove this if able after simplifying search results logic`


### PR DESCRIPTION
* Update `BEST_PRACTICES.md` documentation spelling out `FIXME - VALIDATE EVERY DEV SIGNOFF` as a special case `FIXME` that should be checked every dev signoff as long as the condition being checked is unchanged.
* Convert a few of the project `FIXME`s into `FIXME - VALIDATE EVERY DEV SIGNOFF`