### PR TITLE
Address various compile time warnings

### DIFF
--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/startup/KoinStartupInitializer.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/startup/KoinStartupInitializer.kt
@@ -28,6 +28,9 @@ class KoinStartupInitializer : Initializer<KoinApplication> {
             }
 
             androidContext(context)
+            // Turn definition override off (it is on by default) so Koin throws a `DefinitionOverrideException` when a definition is provided in multiple locations of the graph.
+            // See https://insert-koin.io/docs/reference/koin-core/modules/#overriding-definition-or-module-310
+            allowOverride(override = false)
             modules(
                 listOf(
                     AppModule.module,

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/BaseDataBindingFragment.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/BaseDataBindingFragment.kt
@@ -50,7 +50,7 @@ abstract class BaseDataBindingFragment<FRAGMENT_VIEW_MODEL : BaseViewModel, BIND
         setupBinding(binding)
     }
 
-    /** Use onDestroy(binding) if need access to [binding]. Otherwise, override this function and call super. */
+    /** Use onDestroyView(binding) if need access to [binding]. Otherwise, override this function and call super. */
     @CallSuper
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/MainActivity.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/MainActivity.kt
@@ -44,7 +44,7 @@ class MainActivity : AppCompatActivity() {
             }
             // Don't show the toolbar's AppCompatTextView title, show the one we style
         }
-        navController.addOnDestinationChangedListener { _, destination, arguments ->
+        navController.addOnDestinationChangedListener { _, destination, _ ->
             this@MainActivity.hideKeyboard() // hide keyboard for every destination change - prevents need to manually hide keyboard per fragment just prior to navigating away
             activityViewModel.showToolbar(destination.label?.isNotEmpty() ?: false)
             activityViewModel.setTitle(destination.label.toString())

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/bindingadapters/ViewBindingAdapters.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/bindingadapters/ViewBindingAdapters.kt
@@ -72,7 +72,7 @@ fun EditText.onEditorEnterAction(enterCallback: GeneralCallback?) {
     if (enterCallback == null) {
         setOnEditorActionListener(null)
     } else {
-        setOnEditorActionListener { v, actionId, event ->
+        setOnEditorActionListener { _, actionId, event ->
             val validImeAction = when (actionId) {
                 EditorInfo.IME_ACTION_DONE,
                 EditorInfo.IME_ACTION_SEND,

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileFragment.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileFragment.kt
@@ -19,7 +19,7 @@ class RepositoryFileFragment : BaseDataBindingFragment<RepositoryFileFragmentVie
 
     override fun setupBinding(binding: RepositoryFileFragmentBinding) {
         super.setupBinding(binding)
-        val repo: Repository = activityViewModel.selectedRepo.value ?: return
+        val repo: Repository = activityViewModel.selectedRepo.value
         val file: RepoFile = args.file
         activityViewModel.setTitle(file.path ?: "")
         activityViewModel.showToolbar(true)

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFolderFragment.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFolderFragment.kt
@@ -24,7 +24,7 @@ class RepositoryFolderFragment : BaseDataBindingFragment<RepositoryFolderFragmen
         super.setupBinding(binding)
 
         binding.apply {
-            val repo: Repository = activityViewModel.selectedRepo.value ?: return
+            val repo: Repository = activityViewModel.selectedRepo.value
             val folder: RepoFile = args.file
             activityViewModel.setTitle(folder.path ?: "")
             activityViewModel.showToolbar(true)

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/BaseTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/BaseTest.kt
@@ -29,8 +29,8 @@ open class BaseTest {
         Timber.plant(SystemOutPrintlnTree())
     }
 
-    /** Used to declare a Koin single within a module and load immediately */
-    inline fun <reified T> inlineKoinSingle(override: Boolean = false, crossinline block: Scope.() -> T) {
-        loadKoinModules(module(override = override) { single { block() } })
+    /** Used to declare a Koin single within a module and load immediately, overriding any definitions previously set. */
+    inline fun <reified T> inlineKoinSingle(crossinline block: Scope.() -> T) {
+        loadKoinModules(module { single { block() } })
     }
 }

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryViewModelTest.kt
@@ -1,13 +1,19 @@
 package com.bottlerocketstudios.brarchitecture.ui.repository
 
+import com.bottlerocketstudios.brarchitecture.R
+import com.bottlerocketstudios.brarchitecture.data.model.Repository
 import com.bottlerocketstudios.brarchitecture.test.BaseTest
 import com.bottlerocketstudios.brarchitecture.test.KoinTestRule
 import com.bottlerocketstudios.brarchitecture.test.TestModule
 import com.bottlerocketstudios.brarchitecture.ui.ViewModelItem
+import com.bottlerocketstudios.brarchitecture.ui.util.StringIdHelper
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
-import org.mockito.kotlin.mock
 import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 class RepositoryViewModelTest : BaseTest() {
 
@@ -15,10 +21,12 @@ class RepositoryViewModelTest : BaseTest() {
     val koinRule = KoinTestRule(TestModule.generateMockedTestModule())
 
     @Test
-    fun repositoryViewModel_shouldHaveMembers_whee() {
-        val rvm = RepositoryViewModel(mock {})
+    fun repositoryViewModel_initialized_configuredAsExpected() {
+        inlineKoinSingle { Clock.fixed(Instant.parse("2022-01-26T13:00:00.00Z"), ZoneId.of("UTC")) } // example of using inlineKoinSingle to override Clock in koin module graph
+        val rvm = RepositoryViewModel(Repository(updated = ZonedDateTime.now(Clock.fixed(Instant.parse("2022-01-26T08:00:00.00Z"), ZoneId.of("UTC")))))
 
         assertThat(rvm.repository).isNotNull()
         assertThat(rvm.getItem(0)).isInstanceOf(ViewModelItem::class.java)
+        assertThat(rvm.formattedUpdateTime).isEqualTo(StringIdHelper.Id(R.string.today))
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,11 +74,12 @@ subprojects {
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         kotlinOptions {
-            // Enable experimental coroutines APIs
+            // Enable experimental coroutines APIs. Use `-opt-in` instead of `-Xuse-experimental` or `-Xopt-in`
+            // https://github.com/Kotlin/kotlinx.coroutines/issues/976#issuecomment-657102010 and https://kotlinlang.org/docs/opt-in-requirements.html#module-wide-opt-in
             @Suppress("SuspiciousCollectionReassignment")
             freeCompilerArgs += listOf(
-                "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                "-Xopt-in=kotlin.time.ExperimentalTime",
+                "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                "-opt-in=kotlin.time.ExperimentalTime",
             )
         }
     }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,5 +1,6 @@
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import java.util.Locale
 
 // Provides dependencies that can be used throughout the project build.gradle files
 
@@ -106,7 +107,7 @@ object Config {
 
     // Gradle versions plugin configuration: https://github.com/ben-manes/gradle-versions-plugin#revisions
     fun isNonStable(version: String): Boolean {
-        val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }
+        val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase(Locale.ENGLISH).contains(it) }
         val regex = "^[0-9,.v-]+(-r)?$".toRegex()
         val isStable = stableKeyword || regex.matches(version)
         return isStable.not()

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/model/ServerError.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/model/ServerError.kt
@@ -2,7 +2,7 @@ package com.bottlerocketstudios.brarchitecture.data.model
 
 import android.os.Parcelable
 import com.squareup.moshi.JsonClass
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /** Represents data from an error response. Can be modified to model data from a normalized error response for custom error UI/logic as needed. */
 @JsonClass(generateAdapter = true)

--- a/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/network/HeaderInterceptorMock.kt
+++ b/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/network/HeaderInterceptorMock.kt
@@ -12,7 +12,7 @@ class HeaderInterceptorMock {
     lateinit var requestBuilder: Request.Builder
     fun getMockedChain(): Interceptor.Chain {
         requestBuilder = mock { requestBuilder ->
-            on { header(any(), any()) } doAnswer { invocation ->
+            on { header(any(), any()) } doAnswer { _ ->
                 requestBuilder
             }
         }

--- a/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/test/BaseTest.kt
+++ b/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/test/BaseTest.kt
@@ -29,8 +29,8 @@ open class BaseTest {
         Timber.plant(SystemOutPrintlnTree())
     }
 
-    /** Used to declare a Koin single within a module and load immediately */
-    inline fun <reified T> inlineKoinSingle(override: Boolean = false, crossinline block: Scope.() -> T) {
-        loadKoinModules(module(override = override) { single { block() } })
+    /** Used to declare a Koin single within a module and load immediately, overriding any definitions previously set. */
+    inline fun <reified T> inlineKoinSingle(crossinline block: Scope.() -> T) {
+        loadKoinModules(module { single { block() } })
     }
 }


### PR DESCRIPTION
After updating dependencies, I noticed a variety of compile time warnings that would be good to cleanup. These changes address the warnings.