### PR TITLE
Styles, colors, dimens and theming

### DIFF
--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/devoptions/DevOptionsFragment.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/devoptions/DevOptionsFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -12,7 +11,7 @@ import androidx.navigation.fragment.findNavController
 import com.bottlerocketstudios.brarchitecture.data.buildconfig.BuildConfigProvider
 import com.bottlerocketstudios.brarchitecture.ui.BaseFragment
 import com.bottlerocketstudios.compose.devoptions.DevOptionsScreen
-import com.google.android.material.composethemeadapter.MdcTheme
+import com.bottlerocketstudios.compose.resources.ArchitectureDemoTheme
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -56,11 +55,9 @@ class DevOptionsFragment : BaseFragment<DevOptionsViewModel>() {
 
     @Composable
     private fun OuterScreenContent(viewModel: DevOptionsViewModel) {
-        MdcTheme {
-            Surface {
-                val state = viewModel.toState()
-                DevOptionsScreen(state = state)
-            }
+        ArchitectureDemoTheme {
+            val state = viewModel.toState()
+            DevOptionsScreen(state = state)
         }
     }
 }

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/devoptions/DevOptionsStateConverter.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/devoptions/DevOptionsStateConverter.kt
@@ -5,17 +5,15 @@ import androidx.compose.runtime.collectAsState
 import com.bottlerocketstudios.compose.devoptions.DevOptionsState
 
 @Composable
-fun DevOptionsViewModel.toState(): DevOptionsState {
-    return DevOptionsState(
-        environmentNames = environmentNames.collectAsState(),
-        environmentSpinnerPosition = environmentSpinnerPosition.collectAsState(),
-        baseUrl = baseUrl.collectAsState(),
-        appVersionName = applicationInfo.appVersionName,
-        appVersionCode = applicationInfo.appVersionCode,
-        appId = applicationInfo.appId,
-        buildIdentifier = applicationInfo.buildIdentifier,
-        onEnvironmentChanged = { index -> onEnvironmentChanged(index) },
-        onRestartCtaClick = { onRestartCtaClick() },
-        onForceCrashCtaClicked = { onForceCrashCtaClicked() }
-    )
-}
+fun DevOptionsViewModel.toState() = DevOptionsState(
+    environmentNames = environmentNames.collectAsState(),
+    environmentSpinnerPosition = environmentSpinnerPosition.collectAsState(),
+    baseUrl = baseUrl.collectAsState(),
+    appVersionName = applicationInfo.appVersionName,
+    appVersionCode = applicationInfo.appVersionCode,
+    appId = applicationInfo.appId,
+    buildIdentifier = applicationInfo.buildIdentifier,
+    onEnvironmentChanged = { index -> onEnvironmentChanged(index) },
+    onRestartCtaClick = { onRestartCtaClick() },
+    onForceCrashCtaClicked = { onForceCrashCtaClicked() }
+)

--- a/compose/src/main/java/com/bottlerocketstudios/compose/auth/Login.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/auth/Login.kt
@@ -13,5 +13,4 @@ data class LoginScreenState(
 
 @Composable
 fun LoginScreen(state: LoginScreenState) {
-
 }

--- a/compose/src/main/java/com/bottlerocketstudios/compose/devoptions/DevOptions.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/devoptions/DevOptions.kt
@@ -1,12 +1,11 @@
 package com.bottlerocketstudios.compose.devoptions
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,9 +15,6 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
 import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
@@ -27,6 +23,7 @@ import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -40,13 +37,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.bottlerocketstudios.compose.R
+import com.bottlerocketstudios.compose.resources.ArchitectureDemoTheme
+import com.bottlerocketstudios.compose.resources.black
+import com.bottlerocketstudios.compose.resources.bold
+import com.bottlerocketstudios.compose.resources.light
+import com.bottlerocketstudios.compose.resources.normal
+import com.bottlerocketstudios.compose.widgets.PrimaryButton
 
 data class DevOptionsState(
     val environmentNames: State<List<String>>,
@@ -62,13 +60,27 @@ data class DevOptionsState(
 )
 
 @Composable
+fun DevOptionsScreenTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colors = MaterialTheme.colors.copy(
+            onSurface = black,
+        )
+    ) {
+        content()
+    }
+}
+
+@Composable
 fun DevOptionsScreen(state: DevOptionsState) {
-    Scaffold(floatingActionButton = { FabLayout(state.onRestartCtaClick) }) {
-        Column(
-            modifier = Modifier.fillMaxSize()
-        ) {
-            DropdownEnvMenu(state)
-            ScrollContent(state)
+    DevOptionsScreenTheme {
+        Scaffold(floatingActionButton = { FabLayout(state.onRestartCtaClick) }) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                DropdownEnvMenu(state)
+                ScrollContent(state)
+            }
         }
     }
 }
@@ -77,12 +89,10 @@ fun DevOptionsScreen(state: DevOptionsState) {
 private fun FabLayout(onFabClick: () -> Unit) {
     FloatingActionButton(
         onClick = { onFabClick() },
-        backgroundColor = MaterialTheme.colors.secondary,
         content = {
             Icon(
                 painter = painterResource(id = R.drawable.ic_restart_24),
-                contentDescription = "Restart",
-                tint = Color.White
+                contentDescription = "Restart"
             )
         }
     )
@@ -90,49 +100,31 @@ private fun FabLayout(onFabClick: () -> Unit) {
 
 @Composable
 private fun ScrollContent(state: DevOptionsState) {
-    Column {
+    Surface {
         LazyColumn(
             modifier = Modifier
-                .padding(start = 12.dp, end = 12.dp)
-                .fillMaxHeight()
-                .fillMaxWidth()
-                .weight(1F)
+                .padding(
+                    start = ArchitectureDemoTheme.dimens.grid_1_5,
+                    end = ArchitectureDemoTheme.dimens.grid_1_5
+                )
+                .fillMaxSize()
         ) {
             item {
-                CardDivider(Color.Transparent)
+                Spacer(Modifier.height(ArchitectureDemoTheme.dimens.grid_3))
                 CardLayout { EnvironmentCard(baseUrl = state.baseUrl.value) }
-                CardDivider(MaterialTheme.colors.primary)
+                CardDivider(ArchitectureDemoTheme.colors.primary)
             }
+
             item {
                 CardLayout { AppInfoCard(state = state) }
-                CardDivider(MaterialTheme.colors.primary)
+                CardDivider(ArchitectureDemoTheme.colors.primary)
             }
+
             item {
                 CardLayout { MiscFunctionalityCard(onForceCrashCtaClick = state.onForceCrashCtaClicked) }
-                CardDivider(Color.Transparent)
+                Spacer(Modifier.height(ArchitectureDemoTheme.dimens.grid_3))
             }
         }
-    }
-}
-
-@Composable
-private fun BottomButton(buttonText: String, onClick: () -> Unit) {
-    Button(
-        onClick = { onClick() },
-        modifier = Modifier
-            .padding(8.dp)
-            .wrapContentHeight()
-            .fillMaxWidth(),
-        colors = ButtonDefaults.textButtonColors(
-            backgroundColor = MaterialTheme.colors.primary
-        ),
-        shape = RoundedCornerShape(7.dp),
-        contentPadding = PaddingValues(12.dp)
-    ) {
-        Text(
-            text = buttonText,
-            style = TextStyle(color = Color.White, fontSize = 14.sp)
-        )
     }
 }
 
@@ -154,15 +146,22 @@ private fun AppInfoCard(state: DevOptionsState) {
 @Composable
 private fun MiscFunctionalityCard(onForceCrashCtaClick: () -> Unit) {
     CardTitle(cardTitle = "Misc Functionality")
-    BottomButton(buttonText = "FORCE CRASH", onForceCrashCtaClick)
+    PrimaryButton(
+        buttonText = "FORCE CRASH",
+        onClick = onForceCrashCtaClick,
+        modifier = Modifier.fillMaxWidth()
+    )
 }
 
 @Composable
 private fun CardDivider(dividerColor: Color) {
     Divider(
         color = dividerColor,
-        thickness = 2.dp,
-        modifier = Modifier.padding(top = 12.dp, bottom = 12.dp)
+        thickness = ArchitectureDemoTheme.dimens.grid_0_25,
+        modifier = Modifier.padding(
+            top = ArchitectureDemoTheme.dimens.grid_1_5,
+            bottom = ArchitectureDemoTheme.dimens.grid_1_5
+        )
     )
 }
 
@@ -170,16 +169,9 @@ private fun CardDivider(dividerColor: Color) {
 private fun CardTitle(cardTitle: String) {
     Text(
         cardTitle,
-        style = TextStyle(
-            color = Color.Black,
-            fontSize = 16.sp,
-            textAlign = TextAlign.Start,
-            fontFamily = FontFamily.SansSerif,
-            fontWeight = FontWeight.Normal
-        ),
+        style = MaterialTheme.typography.h3.normal(),
         modifier = Modifier
-            .padding(bottom = 8.dp)
-            .wrapContentHeight()
+            .padding(bottom = ArchitectureDemoTheme.dimens.grid_1)
             .fillMaxWidth()
     )
 }
@@ -188,27 +180,18 @@ private fun CardTitle(cardTitle: String) {
 private fun TitleValueRow(title: String, entryValue: String) {
     Text(
         title,
-        style = TextStyle(
-            color = Color.Black,
-            fontSize = 16.sp,
-            textAlign = TextAlign.Start,
-            fontFamily = FontFamily.SansSerif,
-            fontWeight = FontWeight.Bold
-        ),
+        style = MaterialTheme.typography.h3.bold(),
         modifier = Modifier
-            .padding(top = 8.dp, bottom = 8.dp)
+            .padding(
+                top = ArchitectureDemoTheme.dimens.grid_1,
+                bottom = ArchitectureDemoTheme.dimens.grid_1
+            )
             .wrapContentHeight()
             .fillMaxWidth()
     )
     Text(
         entryValue,
-        style = TextStyle(
-            color = Color.Black,
-            fontSize = 14.sp,
-            textAlign = TextAlign.Start,
-            fontFamily = FontFamily.SansSerif,
-            fontWeight = FontWeight.Light
-        ),
+        style = MaterialTheme.typography.h3.light(),
         modifier = Modifier
             .wrapContentHeight()
             .fillMaxWidth()
@@ -217,10 +200,15 @@ private fun TitleValueRow(title: String, entryValue: String) {
 
 @Composable
 private fun CardLayout(content: @Composable () -> Unit) {
-    Card(elevation = 4.dp) {
+    Card(elevation = ArchitectureDemoTheme.dimens.plane_3) {
         Column(
             modifier = Modifier
-                .padding(start = 8.dp, end = 8.dp, top = 12.dp, bottom = 12.dp)
+                .padding(
+                    start = ArchitectureDemoTheme.dimens.grid_1,
+                    end = ArchitectureDemoTheme.dimens.grid_1,
+                    top = ArchitectureDemoTheme.dimens.grid_1_5,
+                    bottom = ArchitectureDemoTheme.dimens.grid_1_5
+                )
         ) {
             content()
         }
@@ -244,19 +232,23 @@ private fun DropdownEnvMenu(state: DevOptionsState) {
                     .fillMaxWidth()
                     .clickable(onClick = { expanded = true })
                     .height(IntrinsicSize.Min)
-                    .background(
-                        Color.LightGray
-                    )
             ) {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
                         .wrapContentHeight(Alignment.CenterVertically)
                         .weight(1.0F)
-                        .padding(12.dp)
+                        .padding(ArchitectureDemoTheme.dimens.grid_1_5)
                 ) {
-                    Text("Environment Switcher", style = TextStyle(color = if (expanded) MaterialTheme.colors.primary else Color.DarkGray, fontSize = 12.sp))
-                    Text(it, style = TextStyle(color = Color.Black, fontSize = 14.sp))
+                    Text(
+                        text = "Environment Switcher",
+                        style = MaterialTheme.typography.h5.normal(),
+                        color = if (expanded) MaterialTheme.colors.primary else Color.Unspecified
+                    )
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.h4.normal()
+                    )
                 }
 
                 val displayIcon: Painter = painterResource(
@@ -268,7 +260,7 @@ private fun DropdownEnvMenu(state: DevOptionsState) {
                     modifier = Modifier
                         .wrapContentWidth(Alignment.CenterHorizontally)
                         .fillMaxHeight()
-                        .padding(end = 12.dp),
+                        .padding(end = ArchitectureDemoTheme.dimens.grid_1_5),
                     tint = if (expanded) MaterialTheme.colors.primary else Color.DarkGray
                 )
             }
@@ -278,9 +270,6 @@ private fun DropdownEnvMenu(state: DevOptionsState) {
             onDismissRequest = { expanded = false },
             modifier = Modifier
                 .fillMaxWidth()
-                .background(
-                    Color.White
-                )
         ) {
             items.forEachIndexed { index, s ->
                 DropdownMenuItem(onClick = {
@@ -297,21 +286,23 @@ private fun DropdownEnvMenu(state: DevOptionsState) {
 @Preview(showBackground = true)
 @Composable
 private fun PreviewOuterScreenContent() {
-    val spinnerPosition = remember { mutableStateOf(0) }
-    DevOptionsScreen(
-        state = DevOptionsState(
-            environmentNames = remember { mutableStateOf(listOf("POC", "TST", "PROD")) },
-            environmentSpinnerPosition = spinnerPosition,
-            baseUrl = remember { mutableStateOf("https://mock.com") },
-            appVersionName = "10.1.3",
-            appVersionCode = "1001030",
-            appId = "com.example.foo",
-            buildIdentifier = "171",
-            onEnvironmentChanged = { index ->
-                spinnerPosition.value = index
-            },
-            onRestartCtaClick = { },
-            onForceCrashCtaClicked = { }
+    ArchitectureDemoTheme {
+        val spinnerPosition = remember { mutableStateOf(0) }
+        DevOptionsScreen(
+            state = DevOptionsState(
+                environmentNames = remember { mutableStateOf(listOf("POC", "TST", "PROD")) },
+                environmentSpinnerPosition = spinnerPosition,
+                baseUrl = remember { mutableStateOf("https://mock.com") },
+                appVersionName = "10.1.3",
+                appVersionCode = "1001030",
+                appId = "com.example.foo",
+                buildIdentifier = "171",
+                onEnvironmentChanged = { index ->
+                    spinnerPosition.value = index
+                },
+                onRestartCtaClick = { },
+                onForceCrashCtaClicked = { }
+            )
         )
-    )
+    }
 }

--- a/compose/src/main/java/com/bottlerocketstudios/compose/devoptions/DevOptions.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/devoptions/DevOptions.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import com.bottlerocketstudios.compose.R
 import com.bottlerocketstudios.compose.resources.ArchitectureDemoTheme
+import com.bottlerocketstudios.compose.resources.Dimens
 import com.bottlerocketstudios.compose.resources.black
 import com.bottlerocketstudios.compose.resources.bold
 import com.bottlerocketstudios.compose.resources.light
@@ -104,13 +105,13 @@ private fun ScrollContent(state: DevOptionsState) {
         LazyColumn(
             modifier = Modifier
                 .padding(
-                    start = ArchitectureDemoTheme.dimens.grid_1_5,
-                    end = ArchitectureDemoTheme.dimens.grid_1_5
+                    start = Dimens.grid_1_5,
+                    end = Dimens.grid_1_5
                 )
                 .fillMaxSize()
         ) {
             item {
-                Spacer(Modifier.height(ArchitectureDemoTheme.dimens.grid_3))
+                Spacer(Modifier.height(Dimens.grid_3))
                 CardLayout { EnvironmentCard(baseUrl = state.baseUrl.value) }
                 CardDivider(ArchitectureDemoTheme.colors.primary)
             }
@@ -122,7 +123,7 @@ private fun ScrollContent(state: DevOptionsState) {
 
             item {
                 CardLayout { MiscFunctionalityCard(onForceCrashCtaClick = state.onForceCrashCtaClicked) }
-                Spacer(Modifier.height(ArchitectureDemoTheme.dimens.grid_3))
+                Spacer(Modifier.height(Dimens.grid_3))
             }
         }
     }
@@ -157,10 +158,10 @@ private fun MiscFunctionalityCard(onForceCrashCtaClick: () -> Unit) {
 private fun CardDivider(dividerColor: Color) {
     Divider(
         color = dividerColor,
-        thickness = ArchitectureDemoTheme.dimens.grid_0_25,
+        thickness = Dimens.grid_0_25,
         modifier = Modifier.padding(
-            top = ArchitectureDemoTheme.dimens.grid_1_5,
-            bottom = ArchitectureDemoTheme.dimens.grid_1_5
+            top = Dimens.grid_1_5,
+            bottom = Dimens.grid_1_5
         )
     )
 }
@@ -171,7 +172,7 @@ private fun CardTitle(cardTitle: String) {
         cardTitle,
         style = MaterialTheme.typography.h3.normal(),
         modifier = Modifier
-            .padding(bottom = ArchitectureDemoTheme.dimens.grid_1)
+            .padding(bottom = Dimens.grid_1)
             .fillMaxWidth()
     )
 }
@@ -183,8 +184,8 @@ private fun TitleValueRow(title: String, entryValue: String) {
         style = MaterialTheme.typography.h3.bold(),
         modifier = Modifier
             .padding(
-                top = ArchitectureDemoTheme.dimens.grid_1,
-                bottom = ArchitectureDemoTheme.dimens.grid_1
+                top = Dimens.grid_1,
+                bottom = Dimens.grid_1
             )
             .wrapContentHeight()
             .fillMaxWidth()
@@ -200,14 +201,14 @@ private fun TitleValueRow(title: String, entryValue: String) {
 
 @Composable
 private fun CardLayout(content: @Composable () -> Unit) {
-    Card(elevation = ArchitectureDemoTheme.dimens.plane_3) {
+    Card(elevation = Dimens.plane_3) {
         Column(
             modifier = Modifier
                 .padding(
-                    start = ArchitectureDemoTheme.dimens.grid_1,
-                    end = ArchitectureDemoTheme.dimens.grid_1,
-                    top = ArchitectureDemoTheme.dimens.grid_1_5,
-                    bottom = ArchitectureDemoTheme.dimens.grid_1_5
+                    start = Dimens.grid_1,
+                    end = Dimens.grid_1,
+                    top = Dimens.grid_1_5,
+                    bottom = Dimens.grid_1_5
                 )
         ) {
             content()
@@ -217,7 +218,6 @@ private fun CardLayout(content: @Composable () -> Unit) {
 
 // TODO this needs to be update when the next stable release comes out. New Menus
 @Composable
-@Suppress("LongMethod")
 private fun DropdownEnvMenu(state: DevOptionsState) {
     var expanded by remember { mutableStateOf(false) }
     val items = state.environmentNames.value
@@ -226,44 +226,11 @@ private fun DropdownEnvMenu(state: DevOptionsState) {
             .fillMaxWidth()
             .wrapContentSize(Alignment.TopStart)
     ) {
-        items[state.environmentSpinnerPosition.value].let {
-            Row(
-                Modifier
-                    .fillMaxWidth()
-                    .clickable(onClick = { expanded = true })
-                    .height(IntrinsicSize.Min)
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .wrapContentHeight(Alignment.CenterVertically)
-                        .weight(1.0F)
-                        .padding(ArchitectureDemoTheme.dimens.grid_1_5)
-                ) {
-                    Text(
-                        text = "Environment Switcher",
-                        style = MaterialTheme.typography.h5.normal(),
-                        color = if (expanded) MaterialTheme.colors.primary else Color.Unspecified
-                    )
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.h4.normal()
-                    )
-                }
-
-                val displayIcon: Painter = painterResource(
-                    id = R.drawable.ic_arrow_drop_down_24
-                )
-                Icon(
-                    painter = displayIcon,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .wrapContentWidth(Alignment.CenterHorizontally)
-                        .fillMaxHeight()
-                        .padding(end = ArchitectureDemoTheme.dimens.grid_1_5),
-                    tint = if (expanded) MaterialTheme.colors.primary else Color.DarkGray
-                )
-            }
+        EnvironmentList(
+            text = items[state.environmentSpinnerPosition.value],
+            expanded = expanded
+        ) {
+            expanded = true
         }
         DropdownMenu(
             expanded = expanded,
@@ -280,6 +247,47 @@ private fun DropdownEnvMenu(state: DevOptionsState) {
                 }
             }
         }
+    }
+}
+
+@Composable
+fun EnvironmentList(text: String, expanded: Boolean, onClick: () -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .height(IntrinsicSize.Min)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight(Alignment.CenterVertically)
+                .weight(1.0F)
+                .padding(Dimens.grid_1_5)
+        ) {
+            Text(
+                text = "Environment Switcher",
+                style = MaterialTheme.typography.h5.normal(),
+                color = if (expanded) MaterialTheme.colors.primary else Color.Unspecified
+            )
+            Text(
+                text = text,
+                style = MaterialTheme.typography.h4.normal()
+            )
+        }
+
+        val displayIcon: Painter = painterResource(
+            id = R.drawable.ic_arrow_drop_down_24
+        )
+        Icon(
+            painter = displayIcon,
+            contentDescription = null,
+            modifier = Modifier
+                .wrapContentWidth(Alignment.CenterHorizontally)
+                .fillMaxHeight()
+                .padding(end = Dimens.grid_1_5),
+            tint = if (expanded) MaterialTheme.colors.primary else Color.DarkGray
+        )
     }
 }
 

--- a/compose/src/main/java/com/bottlerocketstudios/compose/home/Home.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/home/Home.kt
@@ -10,5 +10,4 @@ data class HomeScreenState(
 
 @Composable
 fun HomeScreen(state: HomeScreenState) {
-
 }

--- a/compose/src/main/java/com/bottlerocketstudios/compose/repository/FileBrowser.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/repository/FileBrowser.kt
@@ -10,5 +10,4 @@ data class FileBrowserScreenState(
 
 @Composable
 fun FileBrowserScreen(state: FileBrowserScreenState) {
-
 }

--- a/compose/src/main/java/com/bottlerocketstudios/compose/repository/RepositoryBrowser.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/repository/RepositoryBrowser.kt
@@ -13,5 +13,4 @@ data class RepositoryBrowserScreenState(
 
 @Composable
 fun RepositoryBrowserScreen(state: RepositoryBrowserScreenState) {
-
 }

--- a/compose/src/main/java/com/bottlerocketstudios/compose/resources/Colors.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/resources/Colors.kt
@@ -1,11 +1,6 @@
 package com.bottlerocketstudios.compose.resources
 
-import androidx.compose.material.Colors
 import androidx.compose.material.lightColors
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
 val br_red = Color(0xffe2231a)

--- a/compose/src/main/java/com/bottlerocketstudios/compose/resources/Colors.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/resources/Colors.kt
@@ -1,0 +1,33 @@
+package com.bottlerocketstudios.compose.resources
+
+import androidx.compose.material.Colors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+val br_red = Color(0xffe2231a)
+val br_dark_red = Color(0xff71110d)
+val br_light_red = Color(0xffe66963)
+val brown_grey = Color(0xff979797)
+val greyish_brown = Color(0xff515151)
+val white = Color(0xffffffff)
+val background_black = Color(0x05000000)
+val black = Color(0xff000000)
+val tertiary = Color(0xff1fada8)
+val brown_grey_two = Color(0xff797979)
+val brown_grey_three = Color(0xff9e9e9e)
+
+val lightColors = lightColors(
+    primary = br_red,
+    primaryVariant = br_dark_red,
+    secondary = br_light_red,
+    background = background_black,
+    surface = white,
+    onPrimary = white,
+    onSecondary = white,
+    onBackground = greyish_brown,
+    onSurface = greyish_brown,
+)

--- a/compose/src/main/java/com/bottlerocketstudios/compose/resources/Dimens.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/resources/Dimens.kt
@@ -1,0 +1,71 @@
+package com.bottlerocketstudios.compose.resources
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+class Dimensions(
+    val grid_0_25: Dp,
+    val grid_0_5: Dp,
+    val grid_1: Dp,
+    val grid_1_5: Dp,
+    val grid_2: Dp,
+    val grid_2_5: Dp,
+    val grid_3: Dp,
+    val grid_3_5: Dp,
+    val grid_4: Dp,
+    val grid_4_5: Dp,
+    val grid_5: Dp,
+    val grid_5_5: Dp,
+    val grid_6: Dp,
+    val plane_0: Dp,
+    val plane_1: Dp,
+    val plane_2: Dp,
+    val plane_3: Dp,
+    val plane_4: Dp,
+    val plane_5: Dp,
+    val minimum_touch_target: Dp = 48.dp,
+)
+
+val smallDimensions = Dimensions(
+    grid_0_25 = 1.5f.dp,
+    grid_0_5 = 3.dp,
+    grid_1 = 6.dp,
+    grid_1_5 = 9.dp,
+    grid_2 = 12.dp,
+    grid_2_5 = 15.dp,
+    grid_3 = 18.dp,
+    grid_3_5 = 21.dp,
+    grid_4 = 24.dp,
+    grid_4_5 = 27.dp,
+    grid_5 = 30.dp,
+    grid_5_5 = 33.dp,
+    grid_6 = 36.dp,
+    plane_0 = 0.dp,
+    plane_1 = 1.dp,
+    plane_2 = 2.dp,
+    plane_3 = 3.dp,
+    plane_4 = 6.dp,
+    plane_5 = 12.dp,
+)
+
+val sw360Dimensions = Dimensions(
+    grid_0_25 = 2.dp,
+    grid_0_5 = 4.dp,
+    grid_1 = 8.dp,
+    grid_1_5 = 12.dp,
+    grid_2 = 16.dp,
+    grid_2_5 = 20.dp,
+    grid_3 = 24.dp,
+    grid_3_5 = 28.dp,
+    grid_4 = 32.dp,
+    grid_4_5 = 36.dp,
+    grid_5 = 40.dp,
+    grid_5_5 = 44.dp,
+    grid_6 = 48.dp,
+    plane_0 = 0.dp,
+    plane_1 = 1.dp,
+    plane_2 = 2.dp,
+    plane_3 = 4.dp,
+    plane_4 = 8.dp,
+    plane_5 = 16.dp,
+)

--- a/compose/src/main/java/com/bottlerocketstudios/compose/resources/Theme.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/resources/Theme.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalConfiguration
 
-
 @Composable
 fun ProvideColors(
     colors: Colors,
@@ -39,7 +38,7 @@ private val LocalAppDimens = staticCompositionLocalOf {
 fun ArchitectureDemoTheme(
     content: @Composable () -> Unit
 ) {
-    //This can be updated later to support a dark mode check
+    // This can be updated later to support a dark mode check
     val colors = lightColors
     val configuration = LocalConfiguration.current
     val dimensions = if (configuration.screenWidthDp <= 360) smallDimensions else sw360Dimensions
@@ -54,7 +53,6 @@ fun ArchitectureDemoTheme(
             }
         }
     }
-
 }
 
 object ArchitectureDemoTheme {
@@ -66,3 +64,7 @@ object ArchitectureDemoTheme {
         @Composable
         get() = LocalAppDimens.current
 }
+
+val Dimens: Dimensions
+    @Composable
+    get() = ArchitectureDemoTheme.dimens

--- a/compose/src/main/java/com/bottlerocketstudios/compose/resources/Theme.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/resources/Theme.kt
@@ -1,0 +1,68 @@
+package com.bottlerocketstudios.compose.resources
+
+import androidx.compose.material.Colors
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalConfiguration
+
+
+@Composable
+fun ProvideColors(
+    colors: Colors,
+    content: @Composable () -> Unit
+) {
+    val colorPalette = remember { colors }
+    CompositionLocalProvider(LocalAppColors provides colorPalette, content = content)
+}
+
+private val LocalAppColors = staticCompositionLocalOf {
+    lightColors
+}
+
+@Composable
+fun ProvideDimens(
+    dimensions: Dimensions,
+    content: @Composable () -> Unit
+) {
+    val dimensionSet = remember { dimensions }
+    CompositionLocalProvider(LocalAppDimens provides dimensionSet, content = content)
+}
+
+private val LocalAppDimens = staticCompositionLocalOf {
+    smallDimensions
+}
+
+@Composable
+fun ArchitectureDemoTheme(
+    content: @Composable () -> Unit
+) {
+    //This can be updated later to support a dark mode check
+    val colors = lightColors
+    val configuration = LocalConfiguration.current
+    val dimensions = if (configuration.screenWidthDp <= 360) smallDimensions else sw360Dimensions
+
+    ProvideDimens(dimensions = dimensions) {
+        ProvideColors(colors = colors) {
+            MaterialTheme(
+                colors = lightColors,
+                typography = typography
+            ) {
+                content()
+            }
+        }
+    }
+
+}
+
+object ArchitectureDemoTheme {
+    val colors: Colors
+        @Composable
+        get() = LocalAppColors.current
+
+    val dimens: Dimensions
+        @Composable
+        get() = LocalAppDimens.current
+}

--- a/compose/src/main/java/com/bottlerocketstudios/compose/resources/Typography.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/resources/Typography.kt
@@ -1,0 +1,57 @@
+package com.bottlerocketstudios.compose.resources
+
+import androidx.compose.material.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val typography = Typography(
+    defaultFontFamily = FontFamily.SansSerif,
+    h1 = TextStyle(
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Medium,
+        fontStyle = FontStyle.Normal
+    ),
+    h2 = TextStyle(
+        fontSize = 18.sp,
+        fontWeight = FontWeight.Medium,
+        fontStyle = FontStyle.Normal,
+        letterSpacing = 0.03.sp
+    ),
+    h3 = TextStyle(
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Medium,
+        fontStyle = FontStyle.Normal,
+        letterSpacing = 0.03.sp
+    ),
+    h4 = TextStyle(
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Medium,
+        fontStyle = FontStyle.Normal,
+        letterSpacing = 0.03.sp
+    ),
+    h5 = TextStyle(
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Medium,
+        fontStyle = FontStyle.Normal,
+        letterSpacing = 0.03.sp
+    ),
+    h6 = TextStyle(
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Normal,
+        fontStyle = FontStyle.Normal,
+        letterSpacing = 0.03.sp
+    ),
+    body1 = TextStyle(
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Normal,
+        fontStyle = FontStyle.Normal,
+        letterSpacing = 0.03.sp
+    )
+)
+
+fun TextStyle.light() = this.copy(fontWeight = FontWeight.Light)
+fun TextStyle.normal() = this.copy(fontWeight = FontWeight.Normal)
+fun TextStyle.bold() = this.copy(fontWeight = FontWeight.Bold)

--- a/compose/src/main/java/com/bottlerocketstudios/compose/snippets/CreateSnippet.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/snippets/CreateSnippet.kt
@@ -19,5 +19,4 @@ data class CreateSnippetScreenState(
 
 @Composable
 fun CreateSnippetScreen(state: CreateSnippetScreenState) {
-
 }

--- a/compose/src/main/java/com/bottlerocketstudios/compose/snippets/SnippetsBrowser.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/snippets/SnippetsBrowser.kt
@@ -10,5 +10,4 @@ data class SnippetsBrowserScreenState(
 
 @Composable
 fun SnippetsBrowserScreen(state: SnippetsBrowserScreenState) {
-
 }

--- a/compose/src/main/java/com/bottlerocketstudios/compose/splash/Splash.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/splash/Splash.kt
@@ -4,6 +4,4 @@ import androidx.compose.runtime.Composable
 
 @Composable
 fun SplashScreen() {
-
 }
-

--- a/compose/src/main/java/com/bottlerocketstudios/compose/user/User.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/user/User.kt
@@ -13,5 +13,4 @@ data class UserScreenState(
 
 @Composable
 fun UserScreen(state: UserScreenState) {
-
 }

--- a/compose/src/main/java/com/bottlerocketstudios/compose/widgets/Buttons.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/widgets/Buttons.kt
@@ -1,0 +1,45 @@
+package com.bottlerocketstudios.compose.widgets
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.bottlerocketstudios.compose.resources.ArchitectureDemoTheme
+
+@Composable
+fun PrimaryButton(
+    buttonText: String,
+    onClick: () -> Unit,
+    modifier: Modifier
+) {
+    Button(
+        onClick = { onClick() },
+        modifier = modifier
+            .padding(ArchitectureDemoTheme.dimens.grid_1),
+        shape = RoundedCornerShape(ArchitectureDemoTheme.dimens.grid_1),
+        contentPadding = PaddingValues(ArchitectureDemoTheme.dimens.grid_1_5)
+    ) {
+        Text(
+            text = buttonText,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewPrimaryButton() {
+    ArchitectureDemoTheme {
+        PrimaryButton(
+            buttonText = "Hello World",
+            onClick = {  },
+            modifier = Modifier
+                .fillMaxWidth()
+        )
+    }
+}

--- a/compose/src/main/java/com/bottlerocketstudios/compose/widgets/Buttons.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/widgets/Buttons.kt
@@ -3,7 +3,6 @@ package com.bottlerocketstudios.compose.widgets
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.Text
@@ -37,7 +36,7 @@ private fun PreviewPrimaryButton() {
     ArchitectureDemoTheme {
         PrimaryButton(
             buttonText = "Hello World",
-            onClick = {  },
+            onClick = { },
             modifier = Modifier
                 .fillMaxWidth()
         )

--- a/compose/src/test/java/com/bottlerocketstudios/compose/ExampleUnitTest.kt
+++ b/compose/src/test/java/com/bottlerocketstudios/compose/ExampleUnitTest.kt
@@ -2,7 +2,7 @@ package com.bottlerocketstudios.compose
 
 import org.junit.Test
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 
 /**
  * Example local unit test, which will execute on the development machine (host).


### PR DESCRIPTION
Took a whack at creating theme values for colors, dimens, typography and such. Updated dev options screen to use these values and rely more on theme defaults than on hardcoded values. 

As there will always be screens that do not exactly follow material theme, I have attempted to show how we could mutate the theme per screen to override the necessary values as well. For easy support of dark mode and material you, we should be relying on the theme for color values as much as possible

I also created a widgets package to house any largely reusable elements, such as styled buttons.