### PR TITLE
Move dispatcher to base view model.

### DIFF
--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/di/AppModule.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/di/AppModule.kt
@@ -25,15 +25,15 @@ import org.koin.dsl.module
 object AppModule {
     val module = module {
         viewModel { MainActivityViewModel(repo = get(), buildConfigProvider = get()) }
-        viewModel { SplashFragmentViewModel(repo = get(), dispatcherProvider = get()) }
-        viewModel { LoginViewModel(repo = get(), buildConfigProvider = get(), toaster = get(), dispatcherProvider = get()) }
-        viewModel { AuthCodeViewModel(repo = get(), buildConfigProvider = get(), toaster = get(), dispatcherProvider = get()) }
-        viewModel { HomeViewModel(repo = get(), dispatcherProvider = get()) }
-        viewModel { RepositoryFragmentViewModel(repo = get(), toaster = get(), dispatcherProvider = get()) }
-        viewModel { RepositoryFileFragmentViewModel(repo = get(), toaster = get(), dispatcherProvider = get()) }
-        viewModel { RepositoryFolderFragmentViewModel(repo = get(), toaster = get(), dispatcherProvider = get()) }
-        viewModel { SnippetsFragmentViewModel(repo = get(), dispatcherProvider = get()) }
-        viewModel { CreateSnippetFragmentViewModel(repo = get(), dispatcherProvider = get()) }
+        viewModel { SplashFragmentViewModel(repo = get()) }
+        viewModel { LoginViewModel(repo = get(), buildConfigProvider = get(), toaster = get()) }
+        viewModel { AuthCodeViewModel(repo = get(), buildConfigProvider = get(), toaster = get()) }
+        viewModel { HomeViewModel(repo = get()) }
+        viewModel { RepositoryFragmentViewModel(repo = get(), toaster = get()) }
+        viewModel { RepositoryFileFragmentViewModel(repo = get(), toaster = get()) }
+        viewModel { RepositoryFolderFragmentViewModel(repo = get(), toaster = get()) }
+        viewModel { SnippetsFragmentViewModel(repo = get()) }
+        viewModel { CreateSnippetFragmentViewModel(repo = get()) }
         viewModel { UserFragmentViewModel(repo = get()) }
         viewModel { DevOptionsViewModel(app = get(), forceCrashLogicImpl = get(), applicationInfoManager = get(), environmentRepository = get(), toaster = get()) }
 

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/BaseViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/BaseViewModel.kt
@@ -6,11 +6,14 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.fragment.findNavController
+import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.navigation.ExternalNavigationEvent
 import com.bottlerocketstudios.brarchitecture.navigation.ExternalNavigationObserver
 import com.bottlerocketstudios.brarchitecture.navigation.NavigationEvent
 import com.bottlerocketstudios.brarchitecture.navigation.NavigationObserver
 import com.hadilq.liveevent.LiveEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,10 +21,20 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import timber.log.Timber
 
 /** Provides [LiveEvent]s for both navigation and external navigation and helper functionality to observe the [LiveData] from a [Fragment] */
-abstract class BaseViewModel : ViewModel() {
+abstract class BaseViewModel : ViewModel(), KoinComponent {
+    protected val dispatcherProvider: DispatcherProvider by inject()
+
+    /**
+     * Helper to launch to IO thread quickly
+     */
+    fun launchIO(block: suspend CoroutineScope.() -> Unit): Job =
+        viewModelScope.launch(dispatcherProvider.IO, block = block)
 
     /**
      * Use to send [NavigationEvent]s (from subclasses).

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/auth/AuthCodeViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/auth/AuthCodeViewModel.kt
@@ -2,32 +2,22 @@ package com.bottlerocketstudios.brarchitecture.ui.auth
 
 import android.content.Intent
 import androidx.core.net.toUri
-import androidx.lifecycle.viewModelScope
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.BuildConfig.BITBUCKET_KEY
 import com.bottlerocketstudios.brarchitecture.data.buildconfig.BuildConfigProvider
 import com.bottlerocketstudios.brarchitecture.data.repository.BitbucketRepository
-import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.infrastructure.toast.Toaster
 import com.bottlerocketstudios.brarchitecture.navigation.ExternalNavigationEvent
 import com.bottlerocketstudios.brarchitecture.navigation.NavigationEvent
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class AuthCodeViewModel(
     private val repo: BitbucketRepository,
     buildConfigProvider: BuildConfigProvider,
     private val toaster: Toaster,
-    private val dispatcherProvider: DispatcherProvider
 ) : BaseViewModel() {
-
-    //  Look at including this in BaseViewModel
-    fun launchIO(block: suspend CoroutineScope.() -> Unit): Job =
-        viewModelScope.launch(dispatcherProvider.IO, block = block)
 
     // UI
     val requestUrl = MutableStateFlow("")

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/auth/LoginViewModel.kt
@@ -2,14 +2,12 @@ package com.bottlerocketstudios.brarchitecture.ui.auth
 
 import android.content.Intent
 import androidx.core.net.toUri
-import androidx.lifecycle.viewModelScope
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.buildconfig.BuildConfigProvider
 import com.bottlerocketstudios.brarchitecture.data.model.CredentialModel
 import com.bottlerocketstudios.brarchitecture.data.model.ProtectedProperty
 import com.bottlerocketstudios.brarchitecture.data.model.toProtectedProperty
 import com.bottlerocketstudios.brarchitecture.data.repository.BitbucketRepository
-import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.infrastructure.toast.Toaster
 import com.bottlerocketstudios.brarchitecture.navigation.ExternalNavigationEvent
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
@@ -17,7 +15,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -25,7 +22,6 @@ class LoginViewModel(
     private val repo: BitbucketRepository,
     buildConfigProvider: BuildConfigProvider,
     private val toaster: Toaster,
-    private val dispatcherProvider: DispatcherProvider
 ) :
     BaseViewModel() {
 
@@ -46,7 +42,7 @@ class LoginViewModel(
 
     fun onLoginClicked() {
         Timber.v("[onLoginClicked]")
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             val creds = CredentialModel(protectedEmail.value, protectedPassword.value)
             creds.validCredentials?.let {
 

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/home/HomeViewModel.kt
@@ -3,23 +3,21 @@ package com.bottlerocketstudios.brarchitecture.ui.home
 import androidx.lifecycle.viewModelScope
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.repository.BitbucketRepository
-import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
 import com.bottlerocketstudios.brarchitecture.ui.HeaderViewModel
 import com.bottlerocketstudios.brarchitecture.ui.repository.RepositoryViewModel
 import com.bottlerocketstudios.brarchitecture.ui.util.StringIdHelper
 import com.xwray.groupie.Section
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class HomeViewModel(repo: BitbucketRepository, private val dispatcherProvider: DispatcherProvider) : BaseViewModel() {
+class HomeViewModel(repo: BitbucketRepository) : BaseViewModel() {
     val user = repo.user
     val repos = repo.repos
     val reposGroup = Section()
 
     init {
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             repos.collect { repoList ->
                 val map = repoList.map { RepositoryViewModel(it) }
                 withContext(dispatcherProvider.Main) {

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileFragmentViewModel.kt
@@ -1,23 +1,23 @@
 package com.bottlerocketstudios.brarchitecture.ui.repository
 
-import androidx.lifecycle.viewModelScope
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.model.ApiResult
 import com.bottlerocketstudios.brarchitecture.data.repository.BitbucketRepository
-import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.infrastructure.toast.Toaster
 import com.bottlerocketstudios.brarchitecture.infrastructure.util.exhaustive
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class RepositoryFileFragmentViewModel(private val repo: BitbucketRepository, private val toaster: Toaster, private val dispatcherProvider: DispatcherProvider) : BaseViewModel() {
+class RepositoryFileFragmentViewModel(
+    private val repo: BitbucketRepository,
+    private val toaster: Toaster,
+) : BaseViewModel() {
     val srcFile: StateFlow<String> = MutableStateFlow("")
     val path: StateFlow<String> = MutableStateFlow("")
     fun loadFile(workspaceSlug: String, repoId: String, @Suppress("UNUSED_PARAMETER") mimetype: String, hash: String, path: String) {
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             val result = repo.getSourceFile(workspaceSlug, repoId, hash, path)
             when (result) {
                 is ApiResult.Success -> srcFile.set(result.data) // TODO: Differentiate UI per type of content (ex: image/text/etc)

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFolderFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFolderFragmentViewModel.kt
@@ -1,28 +1,27 @@
 package com.bottlerocketstudios.brarchitecture.ui.repository
 
-import androidx.lifecycle.viewModelScope
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.model.ApiResult
 import com.bottlerocketstudios.brarchitecture.data.model.RepoFile
 import com.bottlerocketstudios.brarchitecture.data.repository.BitbucketRepository
-import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.infrastructure.toast.Toaster
 import com.bottlerocketstudios.brarchitecture.infrastructure.util.exhaustive
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
 import com.xwray.groupie.Section
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class RepositoryFolderFragmentViewModel(private val repo: BitbucketRepository, private val toaster: Toaster, val dispatcherProvider: DispatcherProvider) : BaseViewModel() {
-    val srcFiles: StateFlow<List<RepoFile>> = MutableStateFlow(emptyList())
+class RepositoryFolderFragmentViewModel(
+    private val repo: BitbucketRepository,
+    private val toaster: Toaster,
+) : BaseViewModel() {
+    private val srcFiles: StateFlow<List<RepoFile>> = MutableStateFlow(emptyList())
     val filesGroup = Section()
     var path: String? = null
 
     init {
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             srcFiles.collect { files ->
                 val map = files.map { RepoFileViewModel(it) }
                 withContext(dispatcherProvider.Main) {
@@ -34,7 +33,7 @@ class RepositoryFolderFragmentViewModel(private val repo: BitbucketRepository, p
     }
 
     fun loadRepo(workspaceSlug: String, repoId: String, hash: String, path: String) {
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             val result = repo.getSourceFolder(workspaceSlug, repoId, hash, path)
             when (result) {
                 is ApiResult.Success -> {

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFragmentViewModel.kt
@@ -1,39 +1,38 @@
 package com.bottlerocketstudios.brarchitecture.ui.repository
 
-import androidx.lifecycle.viewModelScope
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.model.ApiResult
 import com.bottlerocketstudios.brarchitecture.data.model.RepoFile
 import com.bottlerocketstudios.brarchitecture.data.model.Repository
 import com.bottlerocketstudios.brarchitecture.data.repository.BitbucketRepository
-import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.infrastructure.toast.Toaster
 import com.bottlerocketstudios.brarchitecture.infrastructure.util.exhaustive
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
 import com.xwray.groupie.Section
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class RepositoryFragmentViewModel(private val repo: BitbucketRepository, private val toaster: Toaster, private val dispatcherProvider: DispatcherProvider) : BaseViewModel() {
-    val repos = repo.repos
+class RepositoryFragmentViewModel(
+    private val repo: BitbucketRepository,
+    private val toaster: Toaster
+) : BaseViewModel() {
+    private val repos = repo.repos
     var selectedId: String? = null
-    val selectedRepository: StateFlow<Repository?> = MutableStateFlow(null)
-    val srcFiles: StateFlow<List<RepoFile>> = MutableStateFlow(emptyList())
+    private val selectedRepository: StateFlow<Repository?> = MutableStateFlow(null)
+    private val srcFiles: StateFlow<List<RepoFile>> = MutableStateFlow(emptyList())
     val filesGroup = Section()
 
     init {
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             repos.collect {
                 selectRepository(selectedId)
             }
         }
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             repo.refreshMyRepos()
         }
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             srcFiles.collect { files ->
                 val map = files.map { RepoFileViewModel(it) }
                 withContext(dispatcherProvider.Main) {
@@ -50,7 +49,7 @@ class RepositoryFragmentViewModel(private val repo: BitbucketRepository, private
             selectedRepository.setNullable(it)
             it.workspace?.slug?.let { workspaceSlug ->
                 it.name?.let { repoName ->
-                    viewModelScope.launch(dispatcherProvider.IO) {
+                    launchIO {
                         val result = repo.getSource(workspaceSlug, repoName)
                         when (result) {
                             is ApiResult.Success -> srcFiles.set(result.data)

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/snippet/CreateSnippetFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/snippet/CreateSnippetFragmentViewModel.kt
@@ -1,18 +1,15 @@
 package com.bottlerocketstudios.brarchitecture.ui.snippet
 
-import androidx.lifecycle.viewModelScope
 import com.bottlerocketstudios.brarchitecture.data.model.ApiResult
 import com.bottlerocketstudios.brarchitecture.data.repository.BitbucketRepository
-import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.infrastructure.util.exhaustive
 import com.bottlerocketstudios.brarchitecture.navigation.NavigationEvent
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.launch
 
-class CreateSnippetFragmentViewModel(private val repo: BitbucketRepository, private val dispatcherProvider: DispatcherProvider) : BaseViewModel() {
+class CreateSnippetFragmentViewModel(private val repo: BitbucketRepository) : BaseViewModel() {
 
     // Two way databinding
     val title = MutableStateFlow("")
@@ -28,7 +25,7 @@ class CreateSnippetFragmentViewModel(private val repo: BitbucketRepository, priv
 
     fun onCreateClick() {
         failed.set(false)
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             val result = repo.createSnippet(title.value, filename.value, contents.value, private.value)
             when (result) {
                 is ApiResult.Success -> navigationEvent.postValue(NavigationEvent.Up)

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/snippet/SnippetsFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/snippet/SnippetsFragmentViewModel.kt
@@ -1,22 +1,18 @@
 package com.bottlerocketstudios.brarchitecture.ui.snippet
 
-import androidx.lifecycle.viewModelScope
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.repository.BitbucketRepository
-import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.navigation.NavigationEvent
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
 import com.xwray.groupie.Section
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class SnippetsFragmentViewModel(private val repo: BitbucketRepository, private val dispatcherProvider: DispatcherProvider) : BaseViewModel() {
-    val snippets = repo.snippets
+class SnippetsFragmentViewModel(private val repo: BitbucketRepository) : BaseViewModel() {
+    private val snippets = repo.snippets
     val snippetGroup = Section()
 
     init {
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             snippets.collect { snippetList ->
                 val map = snippetList.map { SnippetViewModel(it) }
                 withContext(dispatcherProvider.Main) {
@@ -32,7 +28,7 @@ class SnippetsFragmentViewModel(private val repo: BitbucketRepository, private v
     }
 
     fun refreshSnippets() {
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             repo.refreshMySnippets()
         }
     }

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/splash/SplashFragmentViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/splash/SplashFragmentViewModel.kt
@@ -1,16 +1,13 @@
 package com.bottlerocketstudios.brarchitecture.ui.splash
 
-import androidx.lifecycle.viewModelScope
 import com.bottlerocketstudios.brarchitecture.R
 import com.bottlerocketstudios.brarchitecture.data.repository.BitbucketRepository
-import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.navigation.NavigationEvent
 import com.bottlerocketstudios.brarchitecture.ui.BaseViewModel
-import kotlinx.coroutines.launch
 
-class SplashFragmentViewModel(repo: BitbucketRepository, dispatcherProvider: DispatcherProvider) : BaseViewModel() {
+class SplashFragmentViewModel(repo: BitbucketRepository) : BaseViewModel() {
     init {
-        viewModelScope.launch(dispatcherProvider.IO) {
+        launchIO {
             if (repo.authenticate()) {
                 navigationEvent.postValue(NavigationEvent.Action(R.id.action_splashFragment_to_homeFragment))
             } else {

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/auth/LoginViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/auth/LoginViewModelTest.kt
@@ -23,7 +23,7 @@ class LoginViewModelTest : BaseTest() {
 
     @Test
     fun loginViewModel_shouldEnableLogin_withValidCredentials() = runBlockingTest {
-        val sut = LoginViewModel(mock {}, mock {}, mock {}, dispatcherProvider)
+        val sut = LoginViewModel(mock {}, mock {}, mock {})
         sut.email.value = "test@example.com"
         sut.password.value = "Password1!"
 
@@ -35,7 +35,7 @@ class LoginViewModelTest : BaseTest() {
 
     @Test
     fun loginViewModel_shouldDisableLogin_withInvalidCredentials() = runBlockingTest {
-        val sut = LoginViewModel(mock {}, mock {}, mock {}, dispatcherProvider)
+        val sut = LoginViewModel(mock {}, mock {}, mock {})
         sut.email.value = "t"
         sut.password.value = "P"
 

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/home/HomeViewModelTest.kt
@@ -45,7 +45,7 @@ class HomeViewModelTest : BaseTest() {
 
     @Test
     fun homeViewModel_shouldUpdateAdapter_whenReposRefreshed() = runBlocking {
-        val model = HomeViewModel(repo, dispatcherProvider)
+        val model = HomeViewModel(repo)
 
         assertThat(model.repos.value).hasSize(1)
         assertThat(model.reposGroup.itemCount).isEqualTo(2)
@@ -53,7 +53,7 @@ class HomeViewModelTest : BaseTest() {
 
     @Test
     fun homeViewModel_shouldHaveUser_whenInitialized() = runBlocking {
-        val model = HomeViewModel(repo, dispatcherProvider)
+        val model = HomeViewModel(repo)
 
         assertThat(model.user).isNotNull()
         assertThat(model.user.value?.username).isEqualTo(TEST_USER_NAME)


### PR DESCRIPTION
Moved dispatcher provider to BaseViewModel.kt and used property injection instead of constructor injection.  Also converted existing VMs to new pattern and updated appropriate unit tests.