### PR TITLE
Fix gradle sync issues when verbose logs are enabled in jacocoRoot.gradle

### DIFF
--- a/jacocoRoot.gradle
+++ b/jacocoRoot.gradle
@@ -60,9 +60,9 @@ project.afterEvaluate {
                 println("[jacocoRoot.gradle] sourceName=${sourceName}")
                 println("[jacocoRoot.gradle] rootTaskName '${rootTaskName}'")
                 println("[jacocoRoot.gradle] testTaskName '${testTaskName}'")
-                println("[jacocoRoot.gradle] appModuleTestTaskName '${a_jappModuleTestTaskName}'")
+                println("[jacocoRoot.gradle] appModuleTestTaskName '${appModuleTestTaskName}'")
                 println("[jacocoRoot.gradle] dataModuleTestTaskName '${dataModuleTestTaskName}'")
-                println("[jacocoRoot.gradle] Creating jacoco task named '${taskName}'")
+                println("[jacocoRoot.gradle] Creating jacoco task named '${rootTaskName}'")
             }
 
             task "${rootTaskName}"(type: JacocoReport, dependsOn: ["${appModuleTestTaskName}", "${dataModuleTestTaskName}"]) {


### PR DESCRIPTION
Discovered this issue while testing out verboseLogging for the jacoco gradle files.

Note that the target branch is `develop`. After this is brought in, I can merge `develop` into `compose/develop` to bring these changes in (and any others that might be on `develop` but not yet in `compose/develop`)