### PR TITLE
Add jacoco support for the compose module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id(Config.ApplyPlugins.PARCELIZE)
 }
 
-extra.set("jacocoCoverageThreshold", 0.20.toBigDecimal()) // module specific code coverage verification threshold
+extra.set("jacocoCoverageThreshold", 0.40.toBigDecimal()) // module specific code coverage verification threshold
 apply(from = "../jacocoModule.gradle")
 
 apply(from = "../renameAppBundle.gradle.kts") // configures additional gradle tasks to rename app bundles (when needed)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,11 +19,4 @@
     <!-- Misc -->
     <string name="dev_options_button">Dev Options</string>
 
-    <!-- Values added to exercise unit tests -->
-    <string name="sample_format">Sample %1$s</string>
-    <plurals name="sample_plural_format">
-        <item quantity="one">%1$s was updated %2$d day ago</item>
-        <item quantity="other">%1$s was updated %2$d days ago</item>
-    </plurals>
-
 </resources>

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/home/HomeViewModelTest.kt
@@ -28,7 +28,7 @@ class HomeViewModelTest : BaseTest() {
     val _repos = MutableStateFlow<List<GitRepositoryDto>>(emptyList())
     private val TEST_USER_NAME = "testuser"
     private val dispatcherProvider = TestDispatcherProvider()
-    val repo: BitbucketRepository = mock {
+    val bitbucketRepository: BitbucketRepository = mock {
         on { user }.then { _user }
         on { repos }.then { _repos }
         onBlocking { refreshUser() }.then {
@@ -45,14 +45,16 @@ class HomeViewModelTest : BaseTest() {
 
     @Test
     fun homeViewModel_shouldUpdateAdapter_whenReposRefreshed() = runBlocking {
-        val model = HomeViewModel(repo)
+        inlineKoinSingle { bitbucketRepository }
+        val model = HomeViewModel()
 
         assertThat(model.repos.value).hasSize(1)
     }
 
     @Test
     fun homeViewModel_shouldHaveUser_whenInitialized() = runBlocking {
-        val model = HomeViewModel(repo)
+        inlineKoinSingle { bitbucketRepository }
+        val model = HomeViewModel()
 
         assertThat(model.user).isNotNull()
         assertThat(model.user.value?.username).isEqualTo(TEST_USER_NAME)

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileViewModelTest.kt
@@ -2,4 +2,4 @@ package com.bottlerocketstudios.brarchitecture.ui.repository
 
 import com.bottlerocketstudios.brarchitecture.test.BaseTest
 
-class RepositoryFileActivityViewModelTest : BaseTest()
+class RepositoryFileViewModelTest : BaseTest()

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id(Config.ApplyPlugins.PARCELIZE)
 }
 
+apply(from = "../jacocoModule.gradle")
+
 android {
     compileSdk = Config.AndroidSdkVersions.COMPILE_SDK
     buildToolsVersion = Config.AndroidSdkVersions.BUILD_TOOLS

--- a/compose/src/main/res/values/strings.xml
+++ b/compose/src/main/res/values/strings.xml
@@ -59,4 +59,11 @@
     </plurals>
     <string name="today">Today</string>
 
+    <!-- Values added to exercise unit tests -->
+    <string name="sample_format">Sample %1$s</string>
+    <plurals name="sample_plural_format">
+        <item quantity="one">%1$s was updated %2$d day ago</item>
+        <item quantity="other">%1$s was updated %2$d days ago</item>
+    </plurals>
+
 </resources>

--- a/compose/src/test/java/com/bottlerocketstudios/compose/test/BaseTest.kt
+++ b/compose/src/test/java/com/bottlerocketstudios/compose/test/BaseTest.kt
@@ -1,0 +1,36 @@
+package com.bottlerocketstudios.compose.test
+
+import org.junit.Before
+import org.koin.core.context.loadKoinModules
+import org.koin.core.scope.Scope
+import org.koin.dsl.module
+import timber.log.Timber
+
+/**
+ * Common setup/initialization all JUnit tests should inherit from.
+ *
+ * ### Test Function Naming
+ * All test methods names should follow the template below:
+ *
+ * `methodNameUnderTest_conditionBeingTested_expectedResult`
+ *
+ * ### Test Function Body
+ * 1. Use the **Arrange, Act, Assert** pattern.
+ * 2. Blank lines should indicate the different steps in the pattern (comments denoting each section should not be used).
+ *
+ * Additional resources:
+ * * https://wiki.c2.com/?ArrangeActAssert
+ * * https://xp123.com/articles/3a-arrange-act-assert/
+ * * https://medium.com/swlh/an-experience-of-unit-testing-with-the-arrange-act-assert-aaa-pattern-part-i-53babd01c52b
+ */
+open class BaseTest {
+    @Before
+    fun plantTimber() {
+        Timber.plant(SystemOutPrintlnTree())
+    }
+
+    /** Used to declare a Koin single within a module and load immediately, overriding any definitions previously set. */
+    inline fun <reified T> inlineKoinSingle(crossinline block: Scope.() -> T) {
+        loadKoinModules(module { single { block() } })
+    }
+}

--- a/compose/src/test/java/com/bottlerocketstudios/compose/test/KoinTestRule.kt
+++ b/compose/src/test/java/com/bottlerocketstudios/compose/test/KoinTestRule.kt
@@ -1,0 +1,14 @@
+package com.bottlerocketstudios.compose.test
+
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.module.Module
+
+class KoinTestRule(
+    private val module: Module
+) : TestWatcher() {
+    override fun starting(description: Description?) { startKoin { modules(module) } }
+    override fun finished(description: Description?) = stopKoin()
+}

--- a/compose/src/test/java/com/bottlerocketstudios/compose/test/SystemOutPrintlnTree.kt
+++ b/compose/src/test/java/com/bottlerocketstudios/compose/test/SystemOutPrintlnTree.kt
@@ -1,0 +1,9 @@
+package com.bottlerocketstudios.compose.test
+
+import timber.log.Timber
+
+class SystemOutPrintlnTree : Timber.Tree() {
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        System.out.println(message)
+    }
+}

--- a/compose/src/test/java/com/bottlerocketstudios/compose/test/TestModule.kt
+++ b/compose/src/test/java/com/bottlerocketstudios/compose/test/TestModule.kt
@@ -1,0 +1,13 @@
+package com.bottlerocketstudios.compose.test
+
+import com.bottlerocketstudios.compose.test.mocks.testContext
+import org.koin.dsl.module
+import java.time.Clock
+
+object TestModule {
+    // Default mocks can be overridden using inlineKoinSingle function
+    fun generateMockedTestModule() = module {
+        single { testContext }
+        single<Clock> { Clock.systemDefaultZone() }
+    }
+}

--- a/compose/src/test/java/com/bottlerocketstudios/compose/test/mocks/MockAndroidObjects.kt
+++ b/compose/src/test/java/com/bottlerocketstudios/compose/test/mocks/MockAndroidObjects.kt
@@ -1,0 +1,64 @@
+package com.bottlerocketstudios.compose.test.mocks
+
+import android.app.Application
+import android.content.Context
+import android.content.res.Resources
+import com.bottlerocketstudios.compose.R
+import org.mockito.ArgumentMatchers
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyVararg
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+
+val testResources: Resources = mock {
+    // Order is important here, most generic match first. Last match is final value.
+    on { getQuantityString(any(), any(), anyVararg()) } doReturn ""
+    on { getDrawable(any()) } doReturn null
+    on { getDrawable(any(), any()) } doReturn null
+    on { getString(any(), anyVararg()) } doReturn ""
+
+    // Add specific mocks for getString/getQuantity/etc string/plural/etc references and mocked values here
+    on { getQuantityString(eq(R.plurals.days_ago_plural), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()) } doAnswer {
+        if (it.getArgument<Int>(1) == 1) {
+            "${it.getArgument<Int>(1)} day ago"
+        } else {
+            "${it.getArgument<Int>(2)} days ago"
+        }
+    }
+    on { getQuantityString(eq(R.plurals.sample_plural_format), ArgumentMatchers.anyInt(), ArgumentMatchers.anyString(), ArgumentMatchers.anyInt()) } doAnswer {
+        if (it.getArgument<Int>(1) == 1) {
+            "${it.getArgument<Int>(2)} was updated ${it.getArgument<Int>(3)} day ago"
+        } else {
+            "${it.getArgument<Int>(2)} was updated ${it.getArgument<Int>(3)} days ago"
+        }
+    }
+}
+
+val testContext: Context = mock {
+    // Order is important here, most generic match first. Last match is final value.
+    on { getString(any()) } doReturn ""
+    on { getDrawable(any()) } doReturn null
+    on { getString(any(), anyVararg()) } doReturn ""
+    on { resources } doReturn testResources
+
+    // Add specific mocks for getString/getQuantity/etc string/plural/etc references and mocked values here
+    on { getString(R.string.today) } doReturn "Today"
+    on { getString(R.string.app_name) } doReturn "App Name"
+    on { getString(eq(R.string.sample_format), ArgumentMatchers.anyString()) } doAnswer {
+        "Sample ${it.getArgument<String>(1)}"
+    }
+}
+
+fun testApplicationFactory(
+    mockContext: Context = testContext
+): Application = mock {
+    on { applicationContext } doReturn mockContext
+    on { resources } doReturn testResources
+    // Order is important here, most generic match first. Last match is final value.
+    on { getDrawable(any()) } doReturn null
+    on { getString(any()) } doReturn ""
+    on { getString(any(), anyVararg()) } doReturn ""
+    // Add specific mocks for getString/getQuantity/etc string/plural/etc references and mocked values here
+}

--- a/compose/src/test/java/com/bottlerocketstudios/compose/util/DateTimeUtilsKtTest.kt
+++ b/compose/src/test/java/com/bottlerocketstudios/compose/util/DateTimeUtilsKtTest.kt
@@ -1,10 +1,7 @@
-package com.bottlerocketstudios.brarchitecture.ui.util
+package com.bottlerocketstudios.compose.util
 
-import com.bottlerocketstudios.brarchitecture.R
-import com.bottlerocketstudios.brarchitecture.test.BaseTest
-import com.bottlerocketstudios.compose.util.StringIdHelper
-import com.bottlerocketstudios.compose.util.formattedUpdateTime
-import com.bottlerocketstudios.compose.util.toStringIdHelper
+import com.bottlerocketstudios.compose.R
+import com.bottlerocketstudios.compose.test.BaseTest
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import java.time.Clock

--- a/compose/src/test/java/com/bottlerocketstudios/compose/util/StringIdHelperTest.kt
+++ b/compose/src/test/java/com/bottlerocketstudios/compose/util/StringIdHelperTest.kt
@@ -1,22 +1,24 @@
-package com.bottlerocketstudios.brarchitecture.ui.util
+package com.bottlerocketstudios.compose.util
 
-import com.bottlerocketstudios.brarchitecture.R
-import com.bottlerocketstudios.brarchitecture.test.BaseTest
-import com.bottlerocketstudios.brarchitecture.test.mocks.testContext
-import com.bottlerocketstudios.compose.util.StringIdHelper
-import com.bottlerocketstudios.compose.util.toStringIdHelper
+import com.bottlerocketstudios.compose.R
+import com.bottlerocketstudios.compose.test.BaseTest
+import com.bottlerocketstudios.compose.test.KoinTestRule
+import com.bottlerocketstudios.compose.test.TestModule
 import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
 
 import org.junit.Test
-import org.mockito.kotlin.mock
 
 class StringIdHelperTest : BaseTest() {
+
+    @get:Rule
+    val koinRule = KoinTestRule(TestModule.generateMockedTestModule())
 
     @Test
     fun getString_raw_returnsRawString() {
         val sut = StringIdHelper.Raw("foo")
 
-        val result = sut.getString(mock())
+        val result = sut.getString()
 
         assertThat(result).isEqualTo("foo")
     }
@@ -25,7 +27,7 @@ class StringIdHelperTest : BaseTest() {
     fun getString_id_returnsMatchingIdString() {
         val sut = StringIdHelper.Id(R.string.app_name)
 
-        val result = sut.getString(testContext)
+        val result = sut.getString()
 
         assertThat(result).isEqualTo("App Name")
     }
@@ -34,7 +36,7 @@ class StringIdHelperTest : BaseTest() {
     fun getString_formatWithStringArgs_returnsFormattedString() {
         val sut = StringIdHelper.Format(R.string.sample_format, listOf("Foo"))
 
-        val result = sut.getString(testContext)
+        val result = sut.getString()
 
         assertThat(result).isEqualTo("Sample Foo")
     }
@@ -43,7 +45,7 @@ class StringIdHelperTest : BaseTest() {
     fun getString_formatWithStringIdHelperArgs_returnsFormattedString() {
         val sut = StringIdHelper.Format(R.string.sample_format, listOf(StringIdHelper.Id(R.string.app_name)))
 
-        val result = sut.getString(testContext)
+        val result = sut.getString()
 
         assertThat(result).isEqualTo("Sample App Name")
     }
@@ -52,7 +54,7 @@ class StringIdHelperTest : BaseTest() {
     fun getString_pluralWithStringArgs_returnsFormattedString() {
         val sut = StringIdHelper.Plural(R.plurals.days_ago_plural, 10, listOf(10))
 
-        val result = sut.getString(testContext)
+        val result = sut.getString()
 
         assertThat(result).isEqualTo("10 days ago")
     }
@@ -61,7 +63,7 @@ class StringIdHelperTest : BaseTest() {
     fun getString_pluralWithStringIdHelperArgs_returnsFormattedString() {
         val sut = StringIdHelper.Plural(R.plurals.sample_plural_format, 10, listOf("Foo".toStringIdHelper(), 10))
 
-        val result = sut.getString(testContext)
+        val result = sut.getString()
 
         assertThat(result).isEqualTo("Foo was updated 10 days ago")
     }

--- a/jacocoRoot.gradle
+++ b/jacocoRoot.gradle
@@ -53,6 +53,7 @@ project.afterEvaluate {
             def testTaskName = "test${sourceName.capitalize()}UnitTestCoverage"
             def appModuleTestTaskName = "app:${testTaskName}"
             def dataModuleTestTaskName = "data:${testTaskName}"
+            def composeModuleTestTaskName = "compose:${testTaskName}"
 
             if (verboseLogging) {
                 println("[jacocoRoot.gradle] productFlavorName=${productFlavorName}")
@@ -62,26 +63,30 @@ project.afterEvaluate {
                 println("[jacocoRoot.gradle] testTaskName '${testTaskName}'")
                 println("[jacocoRoot.gradle] appModuleTestTaskName '${appModuleTestTaskName}'")
                 println("[jacocoRoot.gradle] dataModuleTestTaskName '${dataModuleTestTaskName}'")
+                println("[jacocoRoot.gradle] composeModuleTestTaskName '${composeModuleTestTaskName}'")
                 println("[jacocoRoot.gradle] Creating jacoco task named '${rootTaskName}'")
             }
 
-            task "${rootTaskName}"(type: JacocoReport, dependsOn: ["${appModuleTestTaskName}", "${dataModuleTestTaskName}"]) {
+            task "${rootTaskName}"(type: JacocoReport, dependsOn: ["${appModuleTestTaskName}", "${dataModuleTestTaskName}", "${composeModuleTestTaskName}"]) {
                 group = "Reporting"
-                description = "Generate comprehensive project Jacoco coverage report based on app/data modules"
+                description = "Generate comprehensive project Jacoco coverage report based on app/data/compose modules"
 
                 sourceDirectories.from = (files([
                         tasks.getByPath("${appModuleTestTaskName}").sourceDirectories,
-                        tasks.getByPath("${dataModuleTestTaskName}").sourceDirectories
+                        tasks.getByPath("${dataModuleTestTaskName}").sourceDirectories,
+                        tasks.getByPath("${composeModuleTestTaskName}").sourceDirectories
                 ]))
 
                 classDirectories.from = (files([
                         tasks.getByPath("${appModuleTestTaskName}").classDirectories,
-                        tasks.getByPath("${dataModuleTestTaskName}").classDirectories
+                        tasks.getByPath("${dataModuleTestTaskName}").classDirectories,
+                        tasks.getByPath("${composeModuleTestTaskName}").classDirectories
                 ]))
 
                 executionData.from = (files([
                         tasks.getByPath("${appModuleTestTaskName}").executionData,
-                        tasks.getByPath("${dataModuleTestTaskName}").executionData
+                        tasks.getByPath("${dataModuleTestTaskName}").executionData,
+                        tasks.getByPath("${composeModuleTestTaskName}").executionData
                 ]))
                 reports {
                     xml.required.set(true)

--- a/scripts/open_jacoco_report_internalDebug.sh
+++ b/scripts/open_jacoco_report_internalDebug.sh
@@ -4,3 +4,4 @@
 open build/reports/jacoco/testInternalDebugCombinedUnitTestCoverage/html/index.html
 open app/build/reports/jacoco/testInternalDebugUnitTestCoverage/html/index.html
 open data/build/reports/jacoco/testInternalDebugUnitTestCoverage/html/index.html
+open compose/build/reports/jacoco/testInternalDebugUnitTestCoverage/html/index.html


### PR DESCRIPTION
* Setup baseline testing support in `:compose`
* Migrate `DateTimeUtilsKtTest` and `StringIdHelperTest` from `:app` to `:compose`
* Apply `jacocoModule.gradle` in the `:compose` `build.gradle.kts` (enabling jacoco support)
* Adjust `jacocoRoot.gradle` to support `:compose`
* Adjust the `open_jacoco_report_internalDebug.sh` script to open the `:compose` jacoco report

Additionally, update the target code coverage for `:app` to 40%