### PR TITLE
Review commit: Refactor tests to use updated coroutines testing APIs in 1.6.0+

### DIFF
--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/splash/SplashViewModel.kt
@@ -15,10 +15,6 @@ class SplashViewModel : BaseViewModel() {
     val unAuthEvent: SharedFlow<Unit> = MutableSharedFlow()
 
     init {
-        authenticate()
-    }
-
-    fun authenticate() {
         launchIO {
             if (repo.authenticate()) {
                 authEvent.emit(Unit)

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/BaseTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/BaseTest.kt
@@ -1,6 +1,8 @@
 package com.bottlerocketstudios.brarchitecture.test
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.TestRule
@@ -27,16 +29,17 @@ import timber.log.Timber
  * * https://medium.com/swlh/an-experience-of-unit-testing-with-the-arrange-act-assert-aaa-pattern-part-i-53babd01c52b
  */
 open class BaseTest {
-    val testDispatcherProvider = TestDispatcherProvider()
+    /** Defaults to using [UnconfinedTestDispatcher]. Override per test class to potentially use [StandardTestDispatcher] as needed. */
+    open val testDispatcherProvider = UnconfinedTestDispatcher().generateTestDispatcherProvider()
 
     @get:Rule(order = Int.MIN_VALUE)
-    val setDispatcherOnMain = SetDispatcherOnMain(testDispatcherProvider.Unconfined)
+    val setDispatcherOnMain by lazy { SetDispatcherOnMain(testDispatcherProvider.Unconfined) }
 
     @get:Rule
     var rule: TestRule = InstantTaskExecutorRule()
 
     @get:Rule
-    val koinRule = KoinTestRule(TestModule.generateMockedTestModule())
+    val koinRule by lazy { KoinTestRule(TestModule.generateMockedTestModule(testDispatcherProvider)) }
 
     @Before
     fun plantTimber() {

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/TestDispatcherProvider.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/TestDispatcherProvider.kt
@@ -2,11 +2,13 @@ package com.bottlerocketstudios.brarchitecture.test
 
 import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
 
-class TestDispatcherProvider : DispatcherProvider {
-    override val Default: CoroutineDispatcher = Dispatchers.Unconfined
-    override val IO: CoroutineDispatcher = Dispatchers.Unconfined
-    override val Main: CoroutineDispatcher = Dispatchers.Unconfined
-    override val Unconfined: CoroutineDispatcher = Dispatchers.Unconfined
+class TestDispatcherProvider(coroutineDispatcher: CoroutineDispatcher) : DispatcherProvider {
+    override val Default: CoroutineDispatcher = coroutineDispatcher
+    override val IO: CoroutineDispatcher = coroutineDispatcher
+    override val Main: CoroutineDispatcher = coroutineDispatcher
+    override val Unconfined: CoroutineDispatcher = coroutineDispatcher
 }
+
+fun TestDispatcher.generateTestDispatcherProvider() = TestDispatcherProvider(this)

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/TestModule.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/test/TestModule.kt
@@ -13,10 +13,10 @@ import java.time.Clock
 
 object TestModule {
     // Default mocks can be overridden using inlineKoinSingle function
-    fun generateMockedTestModule() = module {
+    fun generateMockedTestModule(testDispatcherProvider: TestDispatcherProvider) = module {
         single { testContext }
         single { testApplicationFactory() }
-        single<DispatcherProvider> { TestDispatcherProvider() }
+        single<DispatcherProvider> { testDispatcherProvider }
         single { ForceCrashLogicImpl }
         single<Clock> { Clock.systemDefaultZone() }
         single<Toaster> { ToasterImpl(testContext) }

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/ComposeActivityViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/ComposeActivityViewModelTest.kt
@@ -9,9 +9,6 @@ import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_USER_DISPLAY_NAME
 import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_USER_LINK
 import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_USER_NAME
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -36,21 +33,21 @@ class ComposeActivityViewModelTest : BaseTest() {
     }
 
     @Test
-    fun showToolbar_initValue_shouldReturnFalse() = runBlocking {
+    fun showToolbar_initValue_shouldReturnFalse() = runTest {
         viewModel.showToolbar.test {
             assertThat(awaitItem()).isFalse()
         }
     }
 
     @Test
-    fun topLevel_initValue_shouldReturnEmptyString() = runBlocking {
+    fun topLevel_initValue_shouldReturnEmptyString() = runTest {
         viewModel.topLevel.test {
             assertThat(awaitItem()).isFalse()
         }
     }
 
     @Test
-    fun selectedRepo_initValue_shouldReturnEmptyRepo() = runBlocking {
+    fun selectedRepo_initValue_shouldReturnEmptyRepo() = runTest {
         viewModel.selectedRepo.test {
             assertThat(awaitItem())
                 .isEqualTo(GitRepository(null, null, null, null, null, null, null))
@@ -58,34 +55,28 @@ class ComposeActivityViewModelTest : BaseTest() {
     }
 
     @Test
-    fun devOptionsEnabled_initValue_shouldReturnTrue() = runBlocking {
+    fun devOptionsEnabled_initValue_shouldReturnTrue() = runTest {
         assertThat(viewModel.devOptionsEnabled).isTrue()
     }
 
     @Test
-    fun avatarUrl_initWithValue_shouldReturnAvatarUrl() = runBlocking {
-        val collector = launch(testDispatcherProvider.Unconfined) { viewModel.avatarUrl.collect() }
+    fun avatarUrl_initWithValue_shouldReturnAvatarUrl() = runTest {
         viewModel.avatarUrl.test {
             assertThat(awaitItem()).isEqualTo(TEST_USER_LINK)
         }
-        collector.cancel()
     }
 
     @Test
-    fun displayName_initWithValue_shouldReturnDisplayName() = runBlocking {
-        val collector = launch(testDispatcherProvider.Unconfined) { viewModel.displayName.collect() }
+    fun displayName_initWithValue_shouldReturnDisplayName() = runTest {
         viewModel.displayName.test {
             assertThat(awaitItem()).isEqualTo(TEST_USER_DISPLAY_NAME)
         }
-        collector.cancel()
     }
 
     @Test
-    fun userName_initWithValue_shouldReturnUserName() = runBlocking {
-        val collector = launch(testDispatcherProvider.Unconfined) { viewModel.username.collect() }
+    fun userName_initWithValue_shouldReturnUserName() = runTest {
         viewModel.username.test {
             assertThat(awaitItem()).isEqualTo(TEST_USER_NAME)
         }
-        collector.cancel()
     }
 }

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/auth/AuthCodeViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/auth/AuthCodeViewModelTest.kt
@@ -6,9 +6,7 @@ import com.bottlerocketstudios.brarchitecture.test.BaseTest
 import com.bottlerocketstudios.brarchitecture.test.mocks.MockBuildConfigProvider
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
@@ -22,7 +20,7 @@ class AuthCodeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun requestUrl_onLoginClicked_shouldReturnMatchingUri() = runBlocking {
+    fun requestUrl_onLoginClicked_shouldReturnMatchingUri() = runTest {
         viewModel.onLoginClicked()
 
         assertThat(viewModel.requestUrl.value).isEqualTo(
@@ -31,12 +29,12 @@ class AuthCodeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun devOptionsEnabled_isDebug_shouldReturnTrue() = runBlocking {
+    fun devOptionsEnabled_isDebug_shouldReturnTrue() = runTest {
         assertThat(viewModel.devOptionsEnabled).isEqualTo(true)
     }
 
     @Test
-    fun devOptionsEnabled_isProduction_shouldReturnFalse() = runBlocking {
+    fun devOptionsEnabled_isProduction_shouldReturnFalse() = runTest {
         inlineKoinSingle { MockBuildConfigProvider.PROD_RELEASE }
         val model = AuthCodeViewModel()
 
@@ -44,27 +42,23 @@ class AuthCodeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun devOptionsEvent_emitValue_shouldReturnUnit() = runBlocking {
-        val collector = launch(testDispatcherProvider.Unconfined) { viewModel.devOptionsEvent.collect() }
+    fun devOptionsEvent_emitValue_shouldReturnUnit() = runTest {
         viewModel.devOptionsEvent.test {
             (viewModel.devOptionsEvent as? MutableSharedFlow)?.emit(Unit)
             assertThat(awaitItem()).isEqualTo(Unit)
         }
-        collector.cancel()
     }
 
     @Test
-    fun homeEvent_emitValue_shouldReturnUnit() = runBlocking {
-        val collector = launch(testDispatcherProvider.Unconfined) { viewModel.homeEvent.collect() }
+    fun homeEvent_emitValue_shouldReturnUnit() = runTest {
         viewModel.homeEvent.test {
             (viewModel.homeEvent as? MutableSharedFlow)?.emit(Unit)
             assertThat(awaitItem()).isEqualTo(Unit)
         }
-        collector.cancel()
     }
 
     @Test
-    fun onDevOptionClicked_devOptionsEventEmit_shouldReturnUnit() = runBlocking {
+    fun onDevOptionClicked_devOptionsEventEmit_shouldReturnUnit() = runTest {
         viewModel.devOptionsEvent.test {
             viewModel.onDevOptionsClicked()
             assertThat(awaitItem()).isEqualTo(Unit)
@@ -72,13 +66,13 @@ class AuthCodeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun requestUrl_onAuthCodeCalled_shouldReturnEmptyString() = runBlocking {
+    fun requestUrl_onAuthCodeCalled_shouldReturnEmptyString() = runTest {
         viewModel.onAuthCode("")
         assertThat(viewModel.requestUrl.value.isBlank()).isEqualTo(true)
     }
 
     @Test
-    fun onAuthCode_authenticateReturnsTrue_HomeEventShouldReturnUnit() = runBlocking {
+    fun onAuthCode_authenticateReturnsTrue_HomeEventShouldReturnUnit() = runTest {
         viewModel.homeEvent.test {
             viewModel.onAuthCode("")
             assertThat(awaitItem()).isEqualTo(Unit)

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/devoptions/DevOptionsViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/devoptions/DevOptionsViewModelTest.kt
@@ -14,7 +14,7 @@ import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_PACKAGE_NAME
 import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_VERSION_CODE
 import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_VERSION_NAME
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
@@ -30,20 +30,20 @@ class DevOptionsViewModelTest : BaseTest() {
     }
 
     @Test
-    fun environmentNames_onViewModelInit_shouldReturnEnvironmentTypeList() = runBlocking {
+    fun environmentNames_onViewModelInit_shouldReturnEnvironmentTypeList() = runTest {
         assertThat(viewModel.environmentNames.value)
             .isEqualTo(listOf(EnvironmentType.STG.shortName, EnvironmentType.PRODUCTION.shortName))
     }
 
     @Test
-    fun environmentSpinnerPosition_onViewModelInit_shouldReturnIndexOfSelectedConfig() = runBlocking {
+    fun environmentSpinnerPosition_onViewModelInit_shouldReturnIndexOfSelectedConfig() = runTest {
         assertThat(viewModel.environmentSpinnerPosition.value).isEqualTo(
             mockEnvironmentRepository.environments.indexOf(mockEnvironmentRepository.selectedConfig)
         )
     }
 
     @Test
-    fun environmentSpinnerPosition_changePosition_shouldReturnNewIndex() = runBlocking {
+    fun environmentSpinnerPosition_changePosition_shouldReturnNewIndex() = runTest {
         MockEnvironmentRepository._selectedConfig = MockEnvironmentRepository._environments[1]
         viewModel = DevOptionsViewModel()
         viewModel.environmentSpinnerPosition.test {
@@ -53,7 +53,7 @@ class DevOptionsViewModelTest : BaseTest() {
     }
 
     @Test
-    fun environmentSpinnerPosition_onEnvironmentChanged_positionShouldUpdate() = runBlocking {
+    fun environmentSpinnerPosition_onEnvironmentChanged_positionShouldUpdate() = runTest {
         // Change environment to PROD
         MockEnvironmentRepository.newEnvironment.value = ENVIRONMENT_PROD
         // Call function to change environment
@@ -69,12 +69,12 @@ class DevOptionsViewModelTest : BaseTest() {
     }
 
     @Test
-    fun baseUrl_initWithSTG_shouldReturnStgBaseUrl() = runBlocking {
+    fun baseUrl_initWithSTG_shouldReturnStgBaseUrl() = runTest {
         assertThat(viewModel.baseUrl.value).isEqualTo(BASE_URL_STG)
     }
 
     @Test
-    fun basUrl_initWithPROD_shouldReturnProdBaseUrl() = runBlocking {
+    fun basUrl_initWithPROD_shouldReturnProdBaseUrl() = runTest {
         // Change init environment
         MockEnvironmentRepository._selectedConfig = ENVIRONMENT_PROD
         // Re "init" viewModel
@@ -84,7 +84,7 @@ class DevOptionsViewModelTest : BaseTest() {
     }
 
     @Test
-    fun baseUrl_onEnvironmentChanged_urlShouldUpdate() = runBlocking {
+    fun baseUrl_onEnvironmentChanged_urlShouldUpdate() = runTest {
         // Change environment to PROD
         MockEnvironmentRepository.newEnvironment.value = ENVIRONMENT_PROD
         viewModel.onEnvironmentChanged(MockEnvironmentRepository._environments.indexOf(ENVIRONMENT_PROD))
@@ -94,7 +94,7 @@ class DevOptionsViewModelTest : BaseTest() {
     }
 
     @Test
-    fun applicationInfo_onViewModelInit_appInfoShouldMatch() = runBlocking {
+    fun applicationInfo_onViewModelInit_appInfoShouldMatch() = runTest {
         // Multiple asserts to check contents; if even one assert fails, this test should fail
         assertThat(viewModel.applicationInfo.appVersionName).isEqualTo(TEST_VERSION_NAME)
         assertThat(viewModel.applicationInfo.appVersionCode).isEqualTo(TEST_VERSION_CODE.toString())

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/profile/ProfileViewModelTest.kt
@@ -9,9 +9,6 @@ import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_USER_LINK
 import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_USER_NICKNAME
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -28,28 +25,28 @@ class ProfileViewModelTest : BaseTest() {
     }
 
     @Test
-    fun avatarUrl_onInitialization_returnsUserAvatarUrl() = runBlocking {
+    fun avatarUrl_onInitialization_returnsUserAvatarUrl() = runTest {
         viewModel.avatarUrl.test {
             assertThat(awaitItem()).isEqualTo(TEST_USER_LINK)
         }
     }
 
     @Test
-    fun displayName_onInitialization_returnsUserDisplayName() = runBlocking {
+    fun displayName_onInitialization_returnsUserDisplayName() = runTest {
         viewModel.displayName.test {
             assertThat(awaitItem()).isEqualTo(TEST_USER_DISPLAY_NAME)
         }
     }
 
     @Test
-    fun nickname_onInitialization_returnsUserNickname() = runBlocking {
+    fun nickname_onInitialization_returnsUserNickname() = runTest {
         viewModel.nickname.test {
             assertThat(awaitItem()).isEqualTo(TEST_USER_NICKNAME)
         }
     }
 
     @Test
-    fun onLogout_onLogoutClicked_shouldReturnUnit() = runBlocking {
+    fun onLogout_onLogoutClicked_shouldReturnUnit() = runTest {
         viewModel.onLogout.test {
             viewModel.onLogoutClicked()
             assertThat(awaitItem()).isEqualTo(Unit)
@@ -57,17 +54,15 @@ class ProfileViewModelTest : BaseTest() {
     }
 
     @Test
-    fun onLogout_emitValue_shouldReturnUnit() = runBlocking {
-        val collector = launch(testDispatcherProvider.Unconfined) { viewModel.onLogout.collect() }
+    fun onLogout_emitValue_shouldReturnUnit() = runTest {
         viewModel.onLogout.test {
             (viewModel.onLogout as? MutableSharedFlow)?.emit(Unit)
             assertThat(awaitItem()).isEqualTo(Unit)
         }
-        collector.cancel()
     }
 
     @Test
-    fun onLogout_onLogout_onLogoutClicked_repoShouldBeCleared() = runBlocking {
+    fun onLogout_onLogout_onLogoutClicked_repoShouldBeCleared() = runTest {
         viewModel.onLogoutClicked()
         assertThat(MockBitBucketRepo.authenticated).isEqualTo(false)
         assertThat(bitbucketRepository.user.value).isEqualTo(null)

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/repository/RepositoryFileViewModelTest.kt
@@ -8,7 +8,7 @@ import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_PATH
 import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_REPO_ID
 import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_REPO_MIME
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
@@ -23,14 +23,14 @@ class RepositoryFileViewModelTest : BaseTest() {
     }
 
     @Test
-    fun srcFile_onInitialization_shouldByteArray() = runBlocking {
+    fun srcFile_onInitialization_shouldByteArray() = runTest {
         viewModel.srcFile.test {
             assertThat(awaitItem()?.size).isEqualTo(4)
         }
     }
 
     @Test
-    fun path_onInitialization_shouldReturnPath() = runBlocking {
+    fun path_onInitialization_shouldReturnPath() = runTest {
         viewModel.path.test {
             assertThat(awaitItem()).isEqualTo(TEST_PATH)
         }

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/snippet/CreateSnippetViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/snippet/CreateSnippetViewModelTest.kt
@@ -9,8 +9,7 @@ import com.bottlerocketstudios.brarchitecture.test.mocks.SNIPPET_FILENAME
 import com.bottlerocketstudios.brarchitecture.test.mocks.SNIPPET_TITLE
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
@@ -24,7 +23,7 @@ class CreateSnippetViewModelTest : BaseTest() {
     }
 
     @Test
-    fun title_setWithTitle_shouldReturnTestTitle() = runBlocking {
+    fun title_setWithTitle_shouldReturnTestTitle() = runTest {
         viewModel.title.test {
             // Assert initial value is an empty string
             assertThat(awaitItem().isBlank()).isEqualTo(true)
@@ -34,7 +33,7 @@ class CreateSnippetViewModelTest : BaseTest() {
     }
 
     @Test
-    fun filename_setWithFileName_shouldReturnTestFilename() = runBlocking {
+    fun filename_setWithFileName_shouldReturnTestFilename() = runTest {
         viewModel.filename.test {
             // Assert initial value is an empty string
             assertThat(awaitItem().isBlank()).isEqualTo(true)
@@ -44,7 +43,7 @@ class CreateSnippetViewModelTest : BaseTest() {
     }
 
     @Test
-    fun contents_setWithContents_shouldReturnTestContents() = runBlocking {
+    fun contents_setWithContents_shouldReturnTestContents() = runTest {
         viewModel.contents.test {
             // Assert initial value is an empty string
             assertThat(awaitItem().isBlank()).isEqualTo(true)
@@ -54,7 +53,7 @@ class CreateSnippetViewModelTest : BaseTest() {
     }
 
     @Test
-    fun private_setToTrue_shouldReturnTrue() = runBlocking {
+    fun private_setToTrue_shouldReturnTrue() = runTest {
         viewModel.private.test {
             // Assert initial value is false
             assertThat(awaitItem()).isEqualTo(false)
@@ -64,7 +63,7 @@ class CreateSnippetViewModelTest : BaseTest() {
     }
 
     @Test
-    fun failed_setToTrue_shouldReturnTrue() = runBlocking {
+    fun failed_setToTrue_shouldReturnTrue() = runTest {
         viewModel.failed.test {
             // Assert initial value is false
             assertThat(awaitItem()).isEqualTo(false)
@@ -74,7 +73,7 @@ class CreateSnippetViewModelTest : BaseTest() {
     }
 
     @Test
-    fun failed_onCreateClickedWithSuccess_shouldReturnFalse() = runBlocking {
+    fun failed_onCreateClickedWithSuccess_shouldReturnFalse() = runTest {
         viewModel.failed.test {
             // Set values
             setSnippetValuesAndPrivacy(false)
@@ -84,10 +83,7 @@ class CreateSnippetViewModelTest : BaseTest() {
     }
 
     @Test
-    fun createEnabled_addValues_shouldReturnTrue() = runBlocking {
-        // Start collection on a flow that is using .groundState extension
-        val collector = launch(testDispatcherProvider.Unconfined) { viewModel.createEnabled.value }
-
+    fun createEnabled_addValues_shouldReturnTrue() = runTest {
         viewModel.createEnabled.test {
             // Assert initial value is false
             assertThat(awaitItem()).isEqualTo(false)
@@ -95,12 +91,10 @@ class CreateSnippetViewModelTest : BaseTest() {
             setSnippetValuesAndPrivacy(false)
             assertThat(awaitItem()).isEqualTo(true)
         }
-
-        collector.cancel()
     }
 
     @Test
-    fun onSuccess_onCreateClickedSuccess_shouldEmitUnit() = runBlocking {
+    fun onSuccess_onCreateClickedSuccess_shouldEmitUnit() = runTest {
         setSnippetValuesAndPrivacy(true)
 
         viewModel.onSuccess.test {
@@ -110,7 +104,7 @@ class CreateSnippetViewModelTest : BaseTest() {
     }
 
     @Test
-    fun failed_onCreateClickedFailure_shouldReturnTrue() = runBlocking {
+    fun failed_onCreateClickedFailure_shouldReturnTrue() = runTest {
         setSnippetValuesAndPrivacy(true)
         MockBitBucketRepo.causeFailure = true
 

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/snippet/SnippetsViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/snippet/SnippetsViewModelTest.kt
@@ -8,7 +8,7 @@ import com.bottlerocketstudios.brarchitecture.test.mocks.SNIPPET_TITLE
 import com.bottlerocketstudios.brarchitecture.test.mocks.TEST_USER_DISPLAY_NAME
 import com.bottlerocketstudios.compose.util.formattedUpdateTime
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import java.time.Clock
@@ -23,7 +23,7 @@ class SnippetsViewModelTest : BaseTest() {
     }
 
     @Test
-    fun snippets_refreshSnippets_shouldReturnSnippetListWithCorrectContent() = runBlocking {
+    fun snippets_refreshSnippets_shouldReturnSnippetListWithCorrectContent() = runTest {
         viewModel.snippets.test {
             viewModel.refreshSnippets()
             // Drop the initial "emptyList()" value and get the updated value from refresh call
@@ -44,7 +44,7 @@ class SnippetsViewModelTest : BaseTest() {
     }
 
     @Test
-    fun createClicked_onCreateClicked_shouldEmitUnit() = runBlocking {
+    fun createClicked_onCreateClicked_shouldEmitUnit() = runTest {
         viewModel.createClicked.test {
             viewModel.onCreateClick()
             assertThat(awaitItem()).isEqualTo(Unit)

--- a/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/splash/SplashViewModelTest.kt
+++ b/app/src/test/java/com/bottlerocketstudios/brarchitecture/ui/splash/SplashViewModelTest.kt
@@ -2,31 +2,34 @@ package com.bottlerocketstudios.brarchitecture.ui.splash
 
 import app.cash.turbine.test
 import com.bottlerocketstudios.brarchitecture.test.BaseTest
+import com.bottlerocketstudios.brarchitecture.test.generateTestDispatcherProvider
 import com.bottlerocketstudios.brarchitecture.test.mocks.MockBitBucketRepo
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class SplashViewModelTest : BaseTest() {
 
+    // Using StandardTestDispatcher to allow testing of emissions sent during ViewModel initialization since doesn't eagerly run coroutines
+    override val testDispatcherProvider = StandardTestDispatcher().generateTestDispatcherProvider()
+
     @Test
-    fun authEvent_authenticatedIsTrue_shouldEmitUnit() = runBlocking {
+    fun authEvent_authenticatedIsTrue_shouldEmitUnit() = runTest {
         MockBitBucketRepo.authenticated = true
 
         val viewModel = SplashViewModel()
         viewModel.authEvent.test {
-            viewModel.authenticate()
             assertThat(awaitItem()).isEqualTo(Unit)
         }
     }
 
     @Test
-    fun unAuthEvent_authenticatedIsFalse_shouldEmitUnit() = runBlocking {
+    fun unAuthEvent_authenticatedIsFalse_shouldEmitUnit() = runTest {
         MockBitBucketRepo.authenticated = false
 
         val viewModel = SplashViewModel()
         viewModel.unAuthEvent.test {
-            viewModel.authenticate()
             assertThat(awaitItem()).isEqualTo(Unit)
         }
     }

--- a/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/model/StatusKtTest.kt
+++ b/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/model/StatusKtTest.kt
@@ -9,7 +9,7 @@ import com.bottlerocketstudios.brarchitecture.domain.models.asSuccess
 import com.bottlerocketstudios.brarchitecture.domain.models.logWrappedExceptions
 import com.bottlerocketstudios.brarchitecture.domain.models.map
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -120,7 +120,7 @@ class StatusKtTest : BaseTest() {
     }
 
     @Test
-    fun wrapExceptions_apiResultSuccess_returnsApiResultSuccess() = runBlocking {
+    fun wrapExceptions_apiResultSuccess_returnsApiResultSuccess() = runTest {
         val blockLambda: suspend () -> Status<String> = {
             Status.Success("baz")
         }
@@ -130,7 +130,7 @@ class StatusKtTest : BaseTest() {
     }
 
     @Test
-    fun wrapExceptions_exceptionInBlockLambda_returnsApiResultFailure() = runBlocking {
+    fun wrapExceptions_exceptionInBlockLambda_returnsApiResultFailure() = runTest {
         val blockLambda: suspend () -> Status<String> = {
             error("exception in processing")
         }

--- a/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/network/BitbucketServiceTest.kt
+++ b/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/network/BitbucketServiceTest.kt
@@ -11,13 +11,13 @@ import com.bottlerocketstudios.brarchitecture.data.serialization.DateTimeAdapter
 import com.bottlerocketstudios.brarchitecture.data.serialization.ProtectedPropertyAdapter
 import com.bottlerocketstudios.brarchitecture.data.test.BaseTest
 import com.google.common.truth.Truth.assertThat
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
 import com.squareup.moshi.Moshi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import org.junit.Ignore
 import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
@@ -36,7 +36,7 @@ class BitbucketServiceTest : BaseTest() {
             tokenType = "bearer",
             scopes = "project account pullrequest"
         )
-        runBlocking {
+        runTest {
             val bitbucketService = createBitbucketService(accessToken)
             val response = bitbucketService.getRepository("REPLACE WITH USERNAME", "REPLACE WITH PRIVATE REPOSITORY")
             val body = response.body()
@@ -58,7 +58,7 @@ class BitbucketServiceTest : BaseTest() {
             tokenType = "bearer",
             scopes = "project account pullrequest"
         )
-        runBlocking {
+        runTest {
             val bitbucketService = createBitbucketService(accessToken)
             val response = bitbucketService.getRepository("REPLACE WITH USERNAME", "REPLACE WITH PRIVATE REPOSITORY")
             val body = response.body()
@@ -72,13 +72,11 @@ class BitbucketServiceTest : BaseTest() {
     }
 
     @Test
-    fun getUser_shouldReturnUser_whenAuthenticated() {
-        runBlocking {
-            val bitbucketService = createBitbucketService(null)
-            val response = bitbucketService.getUser()
-            val body = response.body()
-            val errorBody = response.errorBody()
-        }
+    fun getUser_shouldReturnUser_whenAuthenticated() = runTest {
+        val bitbucketService = createBitbucketService(null)
+        val response = bitbucketService.getUser()
+        val body = response.body()
+        val errorBody = response.errorBody()
     }
 
     // TODO: Consider adding koin-test and use a test koin graph instead of the manual creation here

--- a/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/network/auth/TokenAuthInterceptorTest.kt
+++ b/data/src/test/java/com/bottlerocketstudios/brarchitecture/data/network/auth/TokenAuthInterceptorTest.kt
@@ -15,7 +15,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import retrofit2.Call
 import retrofit2.Response
@@ -42,7 +42,7 @@ class TokenAuthInterceptorTest : BaseTest() {
             on { loadToken() } doAnswer { accessToken }
         }
         val interceptor = TokenAuthInterceptor(service, bitbucketCredentialsRepository)
-        runBlocking {
+        runTest {
             val headerInterceptorMock = HeaderInterceptorMock()
             interceptor.intercept(headerInterceptorMock.getMockedChain())
             // Need to capture two arguments, can't use mockito-kotlin dsl


### PR DESCRIPTION
* Replace `runBlocking` with `runTest`.
* Overhaul the TestDispatcherProvider to use Unconfined implementation of a TestDispatcher.
* Allow each test class to override the TestDispatcherProvider used to run tests with a Standard implementation.
* Remove the the manual collection and collector cancellation from all tests, relying solely on Turbine's `test` functionality for hot/cold flows instead.
* Inline the SplashViewModel authenticate function back into the init block and use the StandardTestDispatcher to allow the event to be captured.