### PR TITLE
Remove comment about not using static composition local.  Move dimens…

### DIFF
--- a/compose/src/main/java/com/bottlerocketstudios/compose/resources/Theme.kt
+++ b/compose/src/main/java/com/bottlerocketstudios/compose/resources/Theme.kt
@@ -3,7 +3,6 @@ package com.bottlerocketstudios.compose.resources
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalConfiguration
@@ -17,7 +16,6 @@ fun ProvideColors(
     CompositionLocalProvider(LocalAppColors provides colorPalette, content = content)
 }
 
-// TODO update this to use compositionLocalOf when a set of dark mode colors has been added
 private val LocalAppColors = staticCompositionLocalOf {
     lightColors
 }
@@ -31,7 +29,7 @@ fun ProvideDimens(
     CompositionLocalProvider(LocalAppDimens provides dimensionSet, content = content)
 }
 
-private val LocalAppDimens = compositionLocalOf {
+private val LocalAppDimens = staticCompositionLocalOf {
     sw360Dimensions
 }
 


### PR DESCRIPTION
… to static composition local

Small dimensions was already working:
<img width="931" alt="image" src="https://user-images.githubusercontent.com/12633149/180262821-1c6765ad-033c-4d83-8061-f77ac28a138b.png">

Here's same inspection with larger device:

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/12633149/180263269-4a0f4b96-e8cc-4364-89a8-584b9d44a100.png">

----

I did cleanup some comments and used  staticCompositionLocalOf for dimens.  As a static composition local will cause entire view tree to recompose when changed but is more efficient that non-static as there are no checks for changes during normal recomposition cycle.  This should be used for things that change rarely and are used across large swaths of UI.  For example; colors and dimens. 