### PR TITLE
ASA 34 - Introduce Jetpack Compose testing

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -325,6 +325,13 @@ private object TestLibraries {
     // https://github.com/cashapp/turbine/blob/trunk/CHANGELOG.md
     // https://github.com/cashapp/turbine/releases
     const val TURBINE = "app.cash.turbine:turbine:0.8.0"
+
+    // Compose - Testing
+    // https://developer.android.com/jetpack/compose/testing
+    // Test rules and transitive dependencies:
+    const val JUNIT_COMPOSE_TESTING = "androidx.compose.ui:ui-test-junit4:${Config.Compose.COMPOSE_VERSION}"
+    // Needed for createComposeRule, but not createAndroidComposeRule:
+    const val MANIFEST_COMPOSE_TESTING = "androidx.compose.ui:ui-test-manifest:${Config.Compose.COMPOSE_VERSION}"
 }
 
 //// Dependency Groups - to be used inside dependencies {} block instead of declaring all necessary lines for a particular dependency
@@ -490,4 +497,9 @@ fun DependencyHandler.kotlinxCoroutineTestingDependencies() {
 
 fun DependencyHandler.turbineDependencies() {
     testImplementation(TestLibraries.TURBINE)
+}
+
+fun DependencyHandler.composeTestDependencies() {
+    androidTestImplementation(TestLibraries.JUNIT_COMPOSE_TESTING)
+    debugImplementation(TestLibraries.MANIFEST_COMPOSE_TESTING)
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -503,3 +503,7 @@ fun DependencyHandler.composeTestDependencies() {
     androidTestImplementation(TestLibraries.JUNIT_COMPOSE_TESTING)
     debugImplementation(TestLibraries.MANIFEST_COMPOSE_TESTING)
 }
+
+fun DependencyHandler.truthAndroidTestDependencies() {
+    androidTestImplementation(TestLibraries.TRUTH)
+}

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -107,4 +107,5 @@ dependencies {
     truthDependencies()
     coreLibraryDesugaringDependencies()
     composeTestDependencies()
+    truthAndroidTestDependencies()
 }

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -105,4 +105,6 @@ dependencies {
     junitDependencies()
     mockitoKotlinDependencies()
     truthDependencies()
+    coreLibraryDesugaringDependencies()
+    composeTestDependencies()
 }

--- a/compose/src/androidTest/java/com.bottlerocketstudios.compose/auth/AuthCodeScreenTest.kt
+++ b/compose/src/androidTest/java/com.bottlerocketstudios.compose/auth/AuthCodeScreenTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import org.junit.Rule
 import org.junit.Test
+import com.google.common.truth.Truth.assertThat
 
 class AuthCodeScreenTest {
 
@@ -126,6 +127,6 @@ class AuthCodeScreenTest {
         val loginButton = composeTestRule.onNodeWithText(loginButtonText)
         loginButton.performClick()
         loginButton.assertTextEquals(loginButtonText)
-        assert(onLoginWasClicked)
+        assertThat(onLoginWasClicked).isTrue()
     }
 }

--- a/compose/src/androidTest/java/com.bottlerocketstudios.compose/auth/AuthCodeScreenTest.kt
+++ b/compose/src/androidTest/java/com.bottlerocketstudios.compose/auth/AuthCodeScreenTest.kt
@@ -1,0 +1,131 @@
+package com.bottlerocketstudios.compose.auth
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.bottlerocketstudios.compose.R
+import com.bottlerocketstudios.compose.resources.ArchitectureDemoTheme
+import com.bottlerocketstudios.compose.util.asMutableState
+import com.google.accompanist.web.WebViewNavigator
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import org.junit.Rule
+import org.junit.Test
+
+class AuthCodeScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+    private val webViewNavigator = WebViewNavigator(testScope)
+
+    @Test
+    fun authCodeScreenImage_doesHaveContentDescription() {
+        // State
+        val state = AuthCodeState(
+            requestUrl = "".asMutableState(),
+            devOptionsEnabled = false,
+            onAuthCode = {},
+            onLoginClicked = {},
+            onSignupClicked = {},
+            onDevOptionsClicked = {},
+            showToolbar = {}
+        )
+
+        composeTestRule.setContent {
+            ArchitectureDemoTheme {
+                AuthCodeScreen(state, webViewNavigator)
+            }
+        }
+
+        val authCodeScreenImageContentDescription = composeTestRule.activity.resources.getString(R.string.splash_image_content_description)
+        // retrieve compose image instance using content desc as identifier
+        val authCodeScreenImage = composeTestRule.onNodeWithContentDescription(authCodeScreenImageContentDescription)
+        authCodeScreenImage.assertIsDisplayed()
+    }
+
+    @Test
+    fun devOptionsButton_doesNotExist() {
+        // State
+        val state = AuthCodeState(
+            requestUrl = "".asMutableState(),
+            devOptionsEnabled = false,
+            onAuthCode = {},
+            onLoginClicked = {},
+            onSignupClicked = {},
+            onDevOptionsClicked = {},
+            showToolbar = {}
+        )
+
+        composeTestRule.setContent {
+            ArchitectureDemoTheme {
+                AuthCodeScreen(state, webViewNavigator)
+            }
+        }
+
+        val devOptionsButtonText = composeTestRule.activity.resources.getString(R.string.dev_options_button).uppercase()
+        // retrieve compose button instance using button text as identifier
+        val devOptionsButton = composeTestRule.onNodeWithText(devOptionsButtonText)
+        devOptionsButton.assertDoesNotExist()
+    }
+
+    @Test
+    fun devOptionsButton_doesExist_andIsDisplayed() {
+        // State
+        val state = AuthCodeState(
+            requestUrl = "".asMutableState(),
+            devOptionsEnabled = true,
+            onAuthCode = {},
+            onLoginClicked = {},
+            onSignupClicked = {},
+            onDevOptionsClicked = {},
+            showToolbar = {}
+        )
+
+        composeTestRule.setContent {
+            ArchitectureDemoTheme {
+                AuthCodeScreen(state, webViewNavigator)
+            }
+        }
+
+        val devOptionsButtonText = composeTestRule.activity.resources.getString(R.string.dev_options_button).uppercase()
+        // retrieve compose button instance using button text as identifier
+        val loginButton = composeTestRule.onNodeWithText(devOptionsButtonText)
+        loginButton.assertIsDisplayed()
+        loginButton.assertExists()
+    }
+
+    @Test
+    fun loginButton_isClicked() {
+        // State
+        var onLoginWasClicked = false
+        val state = AuthCodeState(
+            requestUrl = "".asMutableState(),
+            devOptionsEnabled = true,
+            onAuthCode = {},
+            onLoginClicked = { onLoginWasClicked = true },
+            onSignupClicked = {},
+            onDevOptionsClicked = {},
+            showToolbar = {}
+        )
+
+        composeTestRule.setContent {
+            ArchitectureDemoTheme {
+                AuthCodeScreen(state, webViewNavigator)
+            }
+        }
+
+        val loginButtonText = composeTestRule.activity.resources.getString(R.string.login_button).uppercase()
+        // retrieve compose button instance using button text as identifier
+        val loginButton = composeTestRule.onNodeWithText(loginButtonText)
+        loginButton.performClick()
+        loginButton.assertTextEquals(loginButtonText)
+        assert(onLoginWasClicked)
+    }
+}

--- a/compose/src/androidTest/java/com.bottlerocketstudios.compose/auth/AuthCodeScreenTest.kt
+++ b/compose/src/androidTest/java/com.bottlerocketstudios.compose/auth/AuthCodeScreenTest.kt
@@ -26,7 +26,7 @@ class AuthCodeScreenTest {
     private val webViewNavigator = WebViewNavigator(testScope)
 
     @Test
-    fun authCodeScreenImage_doesHaveContentDescription() {
+    fun authCodeScreenImage_containsContentDescription_andIsDisplayed() {
         // State
         val state = AuthCodeState(
             requestUrl = "".asMutableState(),

--- a/compose/src/androidTest/java/com.bottlerocketstudios.compose/splash/SplashTest.kt
+++ b/compose/src/androidTest/java/com.bottlerocketstudios.compose/splash/SplashTest.kt
@@ -1,0 +1,31 @@
+package com.bottlerocketstudios.compose.splash
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import com.bottlerocketstudios.compose.R
+import com.bottlerocketstudios.compose.resources.ArchitectureDemoTheme
+import org.junit.Rule
+import org.junit.Test
+
+class SplashTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun splashImage_doesExist_andIsDisplayed() {
+        composeTestRule.setContent {
+            ArchitectureDemoTheme {
+                SplashScreen()
+            }
+        }
+
+        val splashImageContentDescription = composeTestRule.activity.resources.getString(R.string.splash_image_content_description)
+        // retrieve compose image instance using content desc as identifier
+        val splashImage = composeTestRule.onNodeWithContentDescription(splashImageContentDescription)
+        splashImage.assertIsDisplayed()
+        splashImage.assertExists()
+    }
+}

--- a/compose/src/androidTest/java/com.bottlerocketstudios.compose/splash/SplashTest.kt
+++ b/compose/src/androidTest/java/com.bottlerocketstudios.compose/splash/SplashTest.kt
@@ -15,7 +15,7 @@ class SplashTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun splashImage_doesExist_andIsDisplayed() {
+    fun splashImage_containsContentDescription_andIsDisplayed() {
         composeTestRule.setContent {
             ArchitectureDemoTheme {
                 SplashScreen()


### PR DESCRIPTION
Added the necessary libraries to perform compose unit tests and added a few example compose tests of the splash and authCode screens