### PR TITLE
ASAA-36 - Use Firebase Remote Config to Check Feature Toggle Flags

### DIFF
--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/ComposeActivity.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/ComposeActivity.kt
@@ -49,9 +49,10 @@ class ComposeActivity : ComponentActivity() {
     /**
      * Same as above set, but using remote config to fetch values.
      */
-    /* private val showSnippetsRemote = featureToggleRepository.featureTogglesByRemoteConfig.value["SHOW_SNIPPETS"] as Boolean
-    private val showPullsRemote = featureToggleRepository.featureTogglesByRemoteConfig.value["SHOW_PULL_REQUESTS"] as Boolean
-    private val webviewConfigRemote = featureToggleRepository.featureTogglesByRemoteConfig.value["WEBVIEW_CONFIGURATION"] as FeatureToggle.ToggleValueEnum.ToggleEnum */
+    /*private val booleanFeatureFlagsRemote = featureToggleRepository.featureToggles.value.filterIsInstance<FeatureToggle.ToggleValueBoolean>()
+    private val showSnippetsRemote = booleanFeatureFlagsRemote.find { it.name == "SHOW_SNIPPETS" }?.value ?: false
+    private val showPullsRemote = booleanFeatureFlagsRemote.find { it.name == "SHOW_PULL_REQUESTS" } ?: false
+    private val webviewConfigRemote = featureToggleRepository.featureTogglesByRemoteConfig.value.filterIsInstance<FeatureToggle.ToggleValueEnum>().find { it.name == "WEBVIEW_CONFIGURATION" }?.value*/
 
     /**
      *   EMPTY_TOOLBAR_TITLE is used to show toolbar without a title.

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/ComposeActivity.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/ComposeActivity.kt
@@ -51,7 +51,7 @@ class ComposeActivity : ComponentActivity() {
      */
     /*private val booleanFeatureFlagsRemote = featureToggleRepository.featureToggles.value.filterIsInstance<FeatureToggle.ToggleValueBoolean>()
     private val showSnippetsRemote = booleanFeatureFlagsRemote.find { it.name == "SHOW_SNIPPETS" }?.value ?: false
-    private val showPullsRemote = booleanFeatureFlagsRemote.find { it.name == "SHOW_PULL_REQUESTS" } ?: false
+    private val showPullsRemote = booleanFeatureFlagsRemote.find { it.name == "SHOW_PULL_REQUESTS" }?.value ?: false
     private val webviewConfigRemote = featureToggleRepository.featureTogglesByRemoteConfig.value.filterIsInstance<FeatureToggle.ToggleValueEnum>().find { it.name == "WEBVIEW_CONFIGURATION" }?.value*/
 
     /**

--- a/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/ComposeActivity.kt
+++ b/app/src/main/java/com/bottlerocketstudios/brarchitecture/ui/ComposeActivity.kt
@@ -38,10 +38,20 @@ class ComposeActivity : ComponentActivity() {
     val activityViewModel: ComposeActivityViewModel by viewModel()
     private val featureToggleRepository: FeatureToggleRepository by inject()
 
-    // Values for showing nav drawer items based on feature toggles
+    /**
+     *  Values for showing nav drawer items based on feature toggles.
+     */
     private val booleanFeatureFlags = featureToggleRepository.featureToggles.value.filterIsInstance<FeatureToggle.ToggleValueBoolean>()
     private val showSnippets = booleanFeatureFlags.find { it.name == "SHOW_SNIPPETS" }?.value ?: false
     private val showPullRequests = booleanFeatureFlags.find { it.name == "SHOW_PULL_REQUESTS" }?.value ?: false
+    //private val webviewConfig = featureToggleRepository.featureToggles.value.filterIsInstance<FeatureToggle.ToggleValueEnum>().find { it.name == "WEBVIEW_CONFIGURATION }?.value
+
+    /**
+     * Same as above set, but using remote config to fetch values.
+     */
+    /* private val showSnippetsRemote = featureToggleRepository.featureTogglesByRemoteConfig.value["SHOW_SNIPPETS"] as Boolean
+    private val showPullsRemote = featureToggleRepository.featureTogglesByRemoteConfig.value["SHOW_PULL_REQUESTS"] as Boolean
+    private val webviewConfigRemote = featureToggleRepository.featureTogglesByRemoteConfig.value["WEBVIEW_CONFIGURATION"] as FeatureToggle.ToggleValueEnum.ToggleEnum */
 
     /**
      *   EMPTY_TOOLBAR_TITLE is used to show toolbar without a title.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ buildscript {
         classpath(Config.BuildScriptPlugins.ANDROID_GRADLE)
         classpath(Config.BuildScriptPlugins.KOTLIN_GRADLE)
         classpath(Config.BuildScriptPlugins.GRADLE_VERSIONS)
+        classpath(Config.BuildScriptPlugins.GOOGLE_SERVICES_VERSION)
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle.kts files

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -63,6 +63,9 @@ object Config {
         // Gradle version plugin; use dependencyUpdates task to view third party dependency updates via `./gradlew dependencyUpdates` or AS Gradle -> [project]] -> Tasks -> help -> dependencyUpdates
         // https://github.com/ben-manes/gradle-versions-plugin/releases
         const val GRADLE_VERSIONS = "com.github.ben-manes:gradle-versions-plugin:0.43.0"
+
+        // Google Services dependency
+        const val GOOGLE_SERVICES_VERSION = "com.google.gms:google-services:4.3.14"
     }
 
     /**
@@ -78,6 +81,7 @@ object Config {
         // const val JACOCO = "jacoco" // https://docs.gradle.org/current/userguide/jacoco_plugin.html - Helper jacoco gradle files manage applying the jacoco plugin
         const val PARCELIZE = "kotlin-parcelize"
         const val KSP = "com.google.devtools.ksp"
+        const val GOOGLE_SERVICES = "com.google.gms.google-services"
         object Kotlin {
             const val ANDROID = "android"
         }
@@ -459,6 +463,11 @@ fun DependencyHandler.chuckerDependencies(devConfigurations: List<Configuration>
     add(productionConfiguration.name, Libraries.CHUCKER_NO_OP) // note the releaseImplementation no-op
 }
 
+fun DependencyHandler.firebaseDependencies() {
+    implementation(platform("com.google.firebase:firebase-bom:31.1.1"))
+    implementation("com.google.firebase:firebase-config-ktx")
+    implementation("com.google.firebase:firebase-analytics-ktx")
+}
 
 // Test specific dependency groups
 fun DependencyHandler.junitDependencies() {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin(Config.ApplyPlugins.Kotlin.ANDROID)
     id(Config.ApplyPlugins.KSP)
     id(Config.ApplyPlugins.PARCELIZE)
+    id(Config.ApplyPlugins.GOOGLE_SERVICES)
 }
 
 extra.set("jacocoCoverageThreshold", 0.30.toBigDecimal()) // module specific code coverage verification threshold
@@ -139,4 +140,7 @@ dependencies {
     archCoreTestingDependencies()
     kotlinxCoroutineTestingDependencies()
     turbineDependencies()
+
+    // Firebase
+    firebaseDependencies()
 }

--- a/data/google-services.json
+++ b/data/google-services.json
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "909985186140",
+    "project_id": "br-feature-toggles",
+    "storage_bucket": "br-feature-toggles.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:909985186140:android:b8a9f3d231c1d66fde8199",
+        "android_client_info": {
+          "package_name": "com.bottlerocketstudios.brarchitecture.data"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "909985186140-h4f67c6bv3etpclqapad8qcahcupulba.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCrxgZcJSi0RmdB6i3ZRjv4nDA6un-3TC4"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "909985186140-h4f67c6bv3etpclqapad8qcahcupulba.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/di/DataModules.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/di/DataModules.kt
@@ -22,6 +22,8 @@ import com.bottlerocketstudios.brarchitecture.domain.repositories.FeatureToggleR
 import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProvider
 import com.bottlerocketstudios.brarchitecture.infrastructure.coroutine.DispatcherProviderImpl
 import com.chuckerteam.chucker.api.ChuckerInterceptor
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.remoteconfig.ktx.remoteConfig
 import com.squareup.moshi.Moshi
 import okhttp3.OkHttpClient
 import org.koin.android.ext.koin.androidContext
@@ -48,6 +50,7 @@ object DataModule {
         single<SharedPreferences>(named(KoinNamedSharedPreferences.Environment)) {
             androidContext().getSharedPreferences("dev_options_prefs", Context.MODE_PRIVATE)
         }
+        single { Firebase.remoteConfig }
     }
 }
 

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/repository/FeatureToggleRepositoryImpl.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/repository/FeatureToggleRepositoryImpl.kt
@@ -17,13 +17,13 @@ import org.koin.core.component.inject
 import timber.log.Timber
 
 class FeatureToggleRepositoryImpl(private val moshi: Moshi) : FeatureToggleRepository, KoinComponent {
-    // DI
+
     private val _featureToggles = MutableStateFlow<Set<FeatureToggle>>(emptySet())
     override val featureToggles: StateFlow<Set<FeatureToggle>> = _featureToggles
 
+    private val remoteConfig by inject<FirebaseRemoteConfig>()
     private val _featureTogglesByConfig = MutableStateFlow<Set<FeatureToggle>>(emptySet())
     override val featureTogglesByRemoteConfig: StateFlow<Set<FeatureToggle>> = _featureTogglesByConfig
-    private val remoteConfig by inject<FirebaseRemoteConfig>()
 
     init {
         initRemoteConfigSettings()

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/repository/FeatureToggleRepositoryImpl.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/repository/FeatureToggleRepositoryImpl.kt
@@ -98,7 +98,8 @@ class FeatureToggleRepositoryImpl(private val moshi: Moshi) : FeatureToggleRepos
 }
 
 @Language("JSON")
-private const val FEATURE_TOGGLE_JSON = """{
+private const val FEATURE_TOGGLE_JSON =
+    """{
         "booleanFlags" :
         [
             {

--- a/data/src/main/res/xml/remote_config_defaults.xml
+++ b/data/src/main/res/xml/remote_config_defaults.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- To use local defaults, enable "Use in-app default" in Firebase Remote Config for the parameter(s) desired.-->
+<defaults>
+  <entry>
+    <key>SHOW_SNIPPETS</key>
+    <value>true</value>
+  </entry>
+  <entry>
+    <key>SHOW_PULL_REQUESTS</key>
+    <value>true</value>
+  </entry>
+</defaults>

--- a/data/src/main/res/xml/remote_config_defaults.xml
+++ b/data/src/main/res/xml/remote_config_defaults.xml
@@ -2,11 +2,15 @@
 <!-- To use local defaults, enable "Use in-app default" in Firebase Remote Config for the parameter(s) desired.-->
 <defaults>
   <entry>
-    <key>SHOW_SNIPPETS</key>
-    <value>true</value>
+    <key>WEBVIEW_CONFIGURATION</key>
+    <value>WEBVIEW</value>
   </entry>
   <entry>
     <key>SHOW_PULL_REQUESTS</key>
+    <value>true</value>
+  </entry>
+  <entry>
+    <key>SHOW_SNIPPETS</key>
     <value>true</value>
   </entry>
 </defaults>

--- a/domain/src/main/java/com/bottlerocketstudios/brarchitecture/domain/repositories/FeatureToggleRepository.kt
+++ b/domain/src/main/java/com/bottlerocketstudios/brarchitecture/domain/repositories/FeatureToggleRepository.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.flow.Flow
 @Suppress("TooManyFunctions")
 interface FeatureToggleRepository : com.bottlerocketstudios.brarchitecture.domain.models.Repository {
     val featureToggles: Flow<List<FeatureToggle>>
+    val featureTogglesByRemoteConfig: Flow<Map<String, Boolean>>
     fun getFeatureTogglesFromJson()
     fun getFeatureToggle(name: String): Boolean
+    fun initRemoteConfigSettings()
+    fun getFeatureToggleFromConfig(name: String): Boolean
 }

--- a/domain/src/main/java/com/bottlerocketstudios/brarchitecture/domain/repositories/FeatureToggleRepository.kt
+++ b/domain/src/main/java/com/bottlerocketstudios/brarchitecture/domain/repositories/FeatureToggleRepository.kt
@@ -13,4 +13,7 @@ interface FeatureToggleRepository : com.bottlerocketstudios.brarchitecture.domai
 
     /** Resets [featureToggles] back to the default value per toggle and potentially triggers an update to [featureToggles] if there are changes. */
     fun resetTogglesToDefaultValues()
+
+    /** Flow of all feature toggles when using Remote Config option. */
+    val featureTogglesByRemoteConfig: StateFlow<Map<String, Any>>
 }

--- a/domain/src/main/java/com/bottlerocketstudios/brarchitecture/domain/repositories/FeatureToggleRepository.kt
+++ b/domain/src/main/java/com/bottlerocketstudios/brarchitecture/domain/repositories/FeatureToggleRepository.kt
@@ -15,5 +15,5 @@ interface FeatureToggleRepository : com.bottlerocketstudios.brarchitecture.domai
     fun resetTogglesToDefaultValues()
 
     /** Flow of all feature toggles when using Remote Config option. */
-    val featureTogglesByRemoteConfig: StateFlow<Map<String, Any>>
+    val featureTogglesByRemoteConfig: StateFlow<Set<FeatureToggle>>
 }


### PR DESCRIPTION
[ASAA-36](https://jira.bottlerocketapps.com/browse/ASAA-36)

**Targeting the 'feature/ASA-39-FeatureToggleJSON' branch as it was easier to test on using the created functionality for that.** The original PR comments for ASAA-39 have been addressed. This branch has been updated to include those changes as well as add string/enum implementation from remote config. Once we merge ASAA-39 branch, we can re-target this to the overall feature's branch.

- Build Firebase Remote Config Implementation
- Define and pass in some data class inputs that contain setup/configuration data needed at runtime
- Ensure the implementation is pluggable/replaceable with another implementation that adheres to a common feature toggle interface/contract

Each time the app gets restarted, the remote config values will be checked. If the minimumFetchInterval has been reached, the app will check the remote config. If minimumFetchInterval has not been reached since the previous app start, the app will revert to the previous fetched value. 

To use the in-app defaults (xml) for a certain parameter, check the bottom right option in below screenshot via the Firebase Remote Config console:

<img width="600" alt="Screenshot 2022-12-28 at 3 56 17 PM" src="https://user-images.githubusercontent.com/93532693/209871051-dca9eaeb-5933-4c0b-8190-89b4f6eb7f9a.png">

For more involved config, we can use different data types in the remote config such as String, Number, Boolean, and JSON. The JSON data type would allow for more complex configuration of feature toggling for each feature (i.e. having a boolean param indicating sub-feature functionality implementation or non-implementation which would be denoted by other params, etc.).

**It's possible we may want to change the Remote Config params to be JSONs so that we can have a value for whether or not we need runtime restart such as we are aiming for in the other feature toggle implementations.** This may be desirable for instances in which the app initialization itself requires different processes, as the config check happens as it launches. The chances of this are likely low, but it's something to keep in mind.
