### PR TITLE
Update Network Modules to Use Service Factory Pattern

### DIFF
--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/BitbucketServiceFactory.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/BitbucketServiceFactory.kt
@@ -1,0 +1,16 @@
+package com.bottlerocketstudios.brarchitecture.data.network
+
+import android.content.Context
+import com.chuckerteam.chucker.api.ChuckerInterceptor
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class BitbucketServiceFactory : ServiceFactory(), KoinComponent {
+
+    private val context: Context by inject()
+
+    override val baseUrl = "https://api.bitbucket.org"
+    override val interceptors = listOf(ChuckerInterceptor.Builder(context).build())
+
+    internal fun produce(): BitbucketService = retrofit.create(BitbucketService::class.java)
+}

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/ServiceFactory.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/ServiceFactory.kt
@@ -1,0 +1,33 @@
+package com.bottlerocketstudios.brarchitecture.data.network
+
+import com.squareup.moshi.Moshi
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
+
+abstract class ServiceFactory : KoinComponent {
+
+    private val moshi: Moshi by inject()
+
+    abstract val baseUrl: String
+    internal abstract val interceptors: List<Interceptor>
+
+    protected val retrofit: Retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(okHttpClient)
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+    }
+
+    private val okHttpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder().apply {
+            interceptors().addAll(interceptors)
+        }.build()
+    }
+}

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/TokenAuthServiceFactory.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/TokenAuthServiceFactory.kt
@@ -1,0 +1,15 @@
+package com.bottlerocketstudios.brarchitecture.data.network
+
+import com.bottlerocketstudios.brarchitecture.data.network.auth.token.TokenAuthInterceptor
+import com.bottlerocketstudios.brarchitecture.data.network.auth.token.TokenAuthService
+import org.koin.core.component.inject
+
+class TokenAuthServiceFactory : ServiceFactory() {
+
+    private val tokenAuthInterceptor: TokenAuthInterceptor by inject()
+
+    override val baseUrl = "https://bitbucket.org/"
+    override val interceptors = listOf(tokenAuthInterceptor)
+
+    internal fun produce(): TokenAuthService = retrofit.create(TokenAuthService::class.java)
+}

--- a/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/auth/token/TokenAuthInterceptor.kt
+++ b/data/src/main/java/com/bottlerocketstudios/brarchitecture/data/network/auth/token/TokenAuthInterceptor.kt
@@ -5,10 +5,15 @@ import com.bottlerocketstudios.brarchitecture.data.network.auth.BitbucketCredent
 import com.squareup.moshi.Moshi
 import okhttp3.Interceptor
 import okhttp3.Response
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import timber.log.Timber
 import java.net.HttpURLConnection
 
-internal class TokenAuthInterceptor(private val tokenAuthService: TokenAuthService, private val credentialsRepo: BitbucketCredentialsRepository) : Interceptor {
+internal class TokenAuthInterceptor : Interceptor, KoinComponent {
+
+    private val tokenAuthService: TokenAuthService by inject()
+    private val credentialsRepo: BitbucketCredentialsRepository by inject()
 
     override fun intercept(chain: Interceptor.Chain): Response {
         getTokenWorker()


### PR DESCRIPTION
As suggested in the QSR-Kit project PR, this PR is to retrofit in the service factory pattern to the network modules in this project.

We could also configure the converter factories in the abstract class if desired. Let me know.